### PR TITLE
refactor: replace navigateToPage with renderPage for consistent navig…

### DIFF
--- a/Frontend/assets/js/main.js
+++ b/Frontend/assets/js/main.js
@@ -66,7 +66,7 @@ async function logout() {
                 localStorage.removeItem('access');
                 localStorage.removeItem('refresh');
                 localStorage.removeItem('access_token_expiry');
-                navigateToPage('login');
+                renderPage('login');
             } else {
                 console.error('Failed to log out:', responseData);
             }

--- a/Frontend/assets/js/register.js
+++ b/Frontend/assets/js/register.js
@@ -39,8 +39,7 @@ function attachRegisterFormListener() {
                 localStorage.setItem('refresh', responseData.refresh);
                 const accessTokenExpiry = new Date().getTime() + 10 * 60 * 1000; // 30 minutes
                 localStorage.setItem('access_token_expiry', accessTokenExpiry);
-                // Navigate to the home page
-                navigateToPage("home");
+                renderPage("home");
             } else if (!response.ok && response.status == 429) {
                 displayErrorMessage("Too many requests. Please try again later.")
             } else {

--- a/Frontend/login.html
+++ b/Frontend/login.html
@@ -16,7 +16,7 @@
             Dont't have an account? 
         </p>
         <p class="text-center text-white small mb-2">
-			<a href="#" onclick="navigateToPage('register')" class="text-primary text-decoration-none fw-bold">Sign up here!</a>
+			<a href="#" onclick="renderPage('register')" class="text-primary text-decoration-none fw-bold">Sign up here!</a>
 		</p>
         <hr class="my-2">
         <h2 class="fs-6 fw-bold mb-2 text-center text-white">Or use your 42Porto Account</h2>

--- a/Frontend/register.html
+++ b/Frontend/register.html
@@ -22,7 +22,7 @@
         <button class="w-100 mb-2 btn btn-sm rounded-2 btn-primary" type="submit">Sign up</button>
         <p class="text-center text-white small mb-2">
             Already have an account? 
-            <a href="#" onclick="navigateToPage('login')" class="text-primary text-decoration-none fw-bold">Login here</a>
+            <a href="#" onclick="renderPage('login')" class="text-primary text-decoration-none fw-bold">Login here</a>
         </p>
         <hr class="my-2">
         <h2 class="fs-6 fw-bold mb-2 text-center text-white">Or use your 42Porto Account</h2>


### PR DESCRIPTION
This pull request includes changes to replace the `navigateToPage` function with the `renderPage` function across various parts of the frontend codebase. The most important changes include updates to JavaScript functions handling user authentication and HTML elements for navigation.

Updates to JavaScript functions:

* [`Frontend/assets/js/main.js`](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fL69-R69): Changed the function call from `navigateToPage('login')` to `renderPage('login')` in the `logout` function.
* [`Frontend/assets/js/register.js`](diffhunk://#diff-e24fbd59714875d40c5a439b727053c7a801e472fb7a20d98798c412224f6159L42-R42): Updated the function call from `navigateToPage("home")` to `renderPage("home")` in the `attachRegisterFormListener` function.

Updates to HTML elements:

* [`Frontend/login.html`](diffhunk://#diff-82d4a1ce4b67748f5efe9b73140d856602e73c1c61db680947eeb2fdd77c2fa2L19-R19): Modified the `onclick` attribute of the "Sign up here!" link to use `renderPage('register')` instead of `navigateToPage('register')`.
* [`Frontend/register.html`](diffhunk://#diff-1dc685b517295f20338673d2411419dc26baf96da7129f97d636083f24b7a4beL25-R25): Changed the `onclick` attribute of the "Login here" link to use `renderPage('login')` instead of `navigateToPage('login')`.