### PR TITLE
Can register with 42

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -8,3 +8,4 @@ djangorestframework-simplejwt==5.4
 channels==4.2.0
 daphne==4.1.2
 channels_redis
+requests==2.32.2

--- a/Backend/users/urls.py
+++ b/Backend/users/urls.py
@@ -6,6 +6,7 @@ urlpatterns = [
     path('login/', views.loginUser, name='login_user'),
     path('logout/', views.logoutUser, name='logout-user'),
     path('users/', views.getUsersData, name='get_users_data'),
+	path('oauth_callback/', views.oauth_callback),
     path('profile/', views.getUserProfile, name='get_user_profile'),
     path('profile/update/', views.updateUserProfile, name='update_user_profile'),
 ]

--- a/Backend/users/views.py
+++ b/Backend/users/views.py
@@ -203,7 +203,6 @@ def oauth_callback(request):
     user_info = user_info_response.json()
     username = user_info['login']
     email = user_info['email']
-
     # Create or authenticate user
     user, created = SiteUser.objects.get_or_create(username=username, defaults={'email': email})
     if created:
@@ -221,4 +220,5 @@ def oauth_callback(request):
         'access': str(refresh.access_token),
         'username': username,
         'email': user.email,
+        'all_info': user_info,
     }, status=status.HTTP_200_OK)

--- a/Frontend/42.html
+++ b/Frontend/42.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>OAuth Redirect</title>
+</head>
+<body>
+    <div class="screen-content">
+        Logging in with 42...
+    </div>
+    <script src="assets/js/42.js"></script>
+</body>
+</html>

--- a/Frontend/assets/js/42.js
+++ b/Frontend/assets/js/42.js
@@ -1,0 +1,49 @@
+function startOAuth() {
+    const clientId = 'u-s4t2ud-a6f40a3d8815d6e54ce1c1ade89e13948ac4e875a56a593543068f6a77e7ddc4';
+    const redirectUri = encodeURIComponent('https://localhost/42');
+    const scope = 'public';
+    const responseType = 'code';
+
+    const oauthUrl = `https://api.intra.42.fr/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=${responseType}&scope=${scope}`;
+    
+    window.location.href = oauthUrl;
+}
+
+// Handle the OAuth callback
+window.onload = async function() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const code = urlParams.get('code');
+
+    if (code) {
+        try {
+            const response = await fetch('http://localhost:8000/api/users/oauth_callback/', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify({ code: code })
+            });
+
+            const data = await response.json();
+            if (response.ok) {
+				console.log(data.username);
+				console.log(data.access);
+				console.log(data.email);
+                // Store the access token and other data
+                localStorage.setItem('access', data.access);
+                localStorage.setItem('refresh', data.refresh);
+                sessionStorage.setItem('username', data.username);
+                sessionStorage.setItem('email', data.email);
+
+                // // Redirect to the home page or another page
+                window.location.href = '/home';
+            } else {
+                console.error('Error:', data.error);
+            }
+        } catch (error) {
+            console.error('Error:', error);
+        }
+    } else {
+        console.error('Authorization code not found');
+    }
+};

--- a/Frontend/assets/js/42.js
+++ b/Frontend/assets/js/42.js
@@ -29,12 +29,15 @@ window.onload = async function() {
 				console.log(data.username);
 				console.log(data.access);
 				console.log(data.email);
+				console.log(data.all_info)
                 // Store the access token and other data
-                localStorage.setItem('access', data.access);
-                localStorage.setItem('refresh', data.refresh);
-                sessionStorage.setItem('username', data.username);
-                sessionStorage.setItem('email', data.email);
-
+// Store the access token and other data
+				localStorage.setItem('access', data.access);
+				localStorage.setItem('refresh', data.refresh);
+				const accessTokenExpiry = new Date().getTime() + 10 * 60 * 1000; // 10 minutes for testing
+				localStorage.setItem('access_token_expiry', accessTokenExpiry);
+				sessionStorage.setItem('username', data.username);
+				sessionStorage.setItem('email', data.email);
                 // // Redirect to the home page or another page
                 window.location.href = '/home';
             } else {

--- a/Frontend/assets/js/main.js
+++ b/Frontend/assets/js/main.js
@@ -10,7 +10,6 @@ const router = {
 
 function displayMessage(message, type) {
   const modal = new MessageModal(type);
-
   modal.show(message);
 }
 
@@ -34,6 +33,7 @@ function isAuthenticated() {
 
 // Page loader
 async function renderPage(page) {
+  console.log(`Attempting to render page: ${page}`);
   if (router.currentPage === page) return;
 
   // Check authentication before navigating to home page
@@ -41,13 +41,13 @@ async function renderPage(page) {
     console.log("Navigating to home, checking and refreshing token...");
     const isAuthenticated = await checkAndRefreshToken();
     if (!isAuthenticated) {
+      console.log("User not authenticated, redirecting to login page.");
       page = "login";
     }
   }
 
   try {
     const screen = document.querySelector(".screen-container");
-
     screen.classList.remove("zoom-in", "zoom-out");
 
     if (page === "home") {
@@ -73,7 +73,9 @@ async function renderPage(page) {
       renderElement("overview");
       lobbyLoad();
     }
+
     history.pushState({ page: page }, '', `/${page}`);
+    router.currentPage = page;
   } catch (error) {
     console.error("Error loading page:", error);
   }
@@ -88,7 +90,7 @@ window.addEventListener("popstate", (e) => {
 
 // Load initial page
 window.addEventListener("load", () => {
-  const initialPage = window.location.hash.slice(1) || "home";
+  const initialPage = window.location.pathname.slice(1) || "home";
   renderPage(initialPage);
 });
 

--- a/Frontend/assets/js/main.js
+++ b/Frontend/assets/js/main.js
@@ -5,6 +5,7 @@ const router = {
     home: "/home.html",
     login: "/login.html",
     register: "/register.html",
+    42: "/42.html",
   },
 };
 

--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -74,5 +74,6 @@
     <script src="assets/js/LoadingOverlay.js"></script>
     <script src="assets/js/ArcadeButton.js"></script>
     <script src="assets/js/ArcadeAudio.js"></script>
+    <script src="assets/js/42.js"></script>
   </body>
 </html>

--- a/Frontend/login.html
+++ b/Frontend/login.html
@@ -16,7 +16,7 @@
             Dont't have an account? 
         </p>
         <p class="text-center text-white small mb-2">
-			<a href="/register" onclick="renderPage('register')" class="text-primary text-decoration-none fw-bold">Sign up here!</a>
+			<a href="/register" onclick="event.preventDefault(); renderPage('register')" class="text-primary text-decoration-none fw-bold">Sign up here!</a>
 		</p>
         <hr class="my-2">
         <h2 class="fs-6 fw-bold mb-2 text-center text-white">Or use your 42Porto Account</h2>

--- a/Frontend/login.html
+++ b/Frontend/login.html
@@ -1,8 +1,8 @@
 <div class="screen-content">
     <h1 class="fw-bold mb-2 fs-3 text-center text-white">Come play Pong!</h1>
     
-	<form id="loginForm" class="p-2">
-		<div id="errorMessages" class="alert alert-danger d-none"></div>
+    <form id="loginForm" class="p-2">
+        <div id="errorMessages" class="alert alert-danger d-none"></div>
         <div class="form-floating mb-2">
             <input type="text" class="form-control form-control-sm rounded-2" id="floatingUsername" placeholder="Username">
             <label for="floatingUsername">Username</label>
@@ -16,24 +16,25 @@
             Dont't have an account? 
         </p>
         <p class="text-center text-white small mb-2">
-			<a href="/register" onclick="event.preventDefault(); renderPage('register')" class="text-primary text-decoration-none fw-bold">Sign up here!</a>
-		</p>
+            <a href="/register" onclick="event.preventDefault(); renderPage('register')" class="text-primary text-decoration-none fw-bold">Sign up here!</a>
+        </p>
         <hr class="my-2">
         <h2 class="fs-6 fw-bold mb-2 text-center text-white">Or use your 42Porto Account</h2>
-		<style>
-			.login-button {
-				background-color: #00babc;
-			}
+        <style>
+            .login-button {
+                background-color: #00babc;
+            }
 
-			.login-button:hover {
-				background-color: #008f8f;
-			}
-		</style>
-        <button type="button" class="login-button text-black py-2 px-3 rounded-2 w-100 d-flex align-items-center justify-content-center">
+            .login-button:hover {
+                background-color: #008f8f;
+            }
+        </style>
+        <button type="button" class="login-button text-black py-2 px-3 rounded-2 w-100 d-flex align-items-center justify-content-center" onclick="startOAuth()">
             <small>Sign in with</small>&nbsp&nbsp&nbsp;
             <img src="/assets/img/42Logo.png" alt="42 Logo" style="width: 30px; height: 30px; background: transparent;" class="ml-2">
         </button>
     </form>
 </div>
 
-<script src="assets/js/login.js"></script>  
+<script src="assets/js/login.js"></script>
+<script src="assets/js/42.js"></script>

--- a/Frontend/register.html
+++ b/Frontend/register.html
@@ -22,7 +22,7 @@
         <button class="w-100 mb-2 btn btn-sm rounded-2 btn-primary" type="submit">Sign up</button>
         <p class="text-center text-white small mb-2">
             Already have an account? 
-            <a href="/login" onclick="renderPage('login')" class="text-primary text-decoration-none fw-bold">Login here</a>
+            <a href="/login" onclick="event.preventDefault(); renderPage('login')" class="text-primary text-decoration-none fw-bold">Login here</a>
         </p>
         <hr class="my-2">
         <h2 class="fs-6 fw-bold mb-2 text-center text-white">Or use your 42Porto Account</h2>


### PR DESCRIPTION
This pull request introduces OAuth integration with 42Porto, alongside several changes to both the backend and frontend to support this feature. The most important changes include adding the OAuth callback endpoint, updating the frontend to handle OAuth, and modifying the user authentication flow.

### Backend Changes:
* Added `requests` dependency in `requirements.txt` to handle HTTP requests.
* Added a new OAuth callback endpoint in `Backend/users/views.py` to handle the OAuth flow and create or authenticate users.
* Updated `Backend/users/urls.py` to include the new OAuth callback path.

### Frontend Changes:
* Created a new HTML file `Frontend/42.html` to handle the OAuth redirection.
* Added a new JavaScript file `Frontend/assets/js/42.js` to initiate the OAuth process and handle the callback.
* Updated `Frontend/assets/js/main.js` to include the new route for the OAuth page and improved the page rendering logic. [[1]](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fR8-L13) [[2]](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fR37-L50) [[3]](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fR77-R79) [[4]](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fL91-R94)
* Added the OAuth script to the main HTML files (`Frontend/index.html`, `Frontend/login.html`, `Frontend/register.html`) to support OAuth login. [[1]](diffhunk://#diff-95aa506b5fe2ea71174bcc8d0c0e1fd7bb61fe0171d5de23035d8548a5a9af63R77) [[2]](diffhunk://#diff-82d4a1ce4b67748f5efe9b73140d856602e73c1c61db680947eeb2fdd77c2fa2L19-R19) [[3]](diffhunk://#diff-82d4a1ce4b67748f5efe9b73140d856602e73c1c61db680947eeb2fdd77c2fa2L32-R40) [[4]](diffhunk://#diff-1dc685b517295f20338673d2411419dc26baf96da7129f97d636083f24b7a4beL25-R25)