### PR TITLE
40 user can delete account

### DIFF
--- a/Backend/users/urls.py
+++ b/Backend/users/urls.py
@@ -5,6 +5,7 @@ urlpatterns = [
     path('create/', views.create_user, name='create_user'),
     path('login/', views.loginUser, name='login_user'),
     path('logout/', views.logoutUser, name='logout-user'),
+    path('delete/', views.deleteUser, name='delete-user'),
     path('users/', views.getUsersData, name='get_users_data'),
 	path('oauth_callback/', views.oauth_callback),
     path('profile/', views.getUserProfile, name='get_user_profile'),

--- a/Backend/users/views.py
+++ b/Backend/users/views.py
@@ -96,6 +96,26 @@ def logoutUser(request):
     except Exception as e:
         return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
     
+@api_view(['DELETE'])
+@permission_classes([IsAuthenticated])
+def deleteUser(request):
+    try:
+        user = request.user
+        # Invalidate all user tokens
+        OutstandingToken.objects.filter(user=user).delete()
+        
+        user.delete()
+        
+        return Response(
+            {"detail": "Account deleted successfully"}, 
+            status=status.HTTP_204_NO_CONTENT
+        )
+    except Exception as e:
+        return Response(
+            {"error": str(e)}, 
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
+
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])
 def getUserProfile(request):

--- a/Frontend/assets/js/profile.js
+++ b/Frontend/assets/js/profile.js
@@ -160,7 +160,9 @@ async function loadProfileData() {
 }
 
 async function deleteAccount() {
+  const loadingOverlay = new LoadingOverlay();
   try {
+    loadingOverlay.show();
     const response = await fetch("http://localhost:8000/api/users/delete/", {
       method: "DELETE",
       headers: {
@@ -171,14 +173,15 @@ async function deleteAccount() {
     if (response.ok) {
       // Clear local storage
       localStorage.clear();
-      // Redirect to login
-      renderPage("login");
     } else {
       alert("Failed to delete account");
     }
   } catch (error) {
     console.error("Error deleting account:", error);
     alert("Error deleting account");
+  } finally {
+    loadingOverlay.hide();
+    renderPage("login");
   }
 }
 

--- a/Frontend/assets/js/profile.js
+++ b/Frontend/assets/js/profile.js
@@ -47,7 +47,6 @@ async function attachProfileFormListener() {
 
       // Show success message
       displayMessage("Profile updated successfully", MessageType.SUCCESS);
-      renderPage("home");
       renderElement("overview");
     } catch (error) {
       console.error("❌ Error updating profile:", error);
@@ -157,6 +156,29 @@ async function loadProfileData() {
       .join("");
   } catch (error) {
     displayMessage("Failed to load profile data", MessageType.ERROR);
+  }
+}
+
+async function deleteAccount() {
+  try {
+    const response = await fetch("http://localhost:8000/api/users/delete/", {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem("access")}`,
+      },
+    });
+
+    if (response.ok) {
+      // Clear local storage
+      localStorage.clear();
+      // Redirect to login
+      renderPage("login");
+    } else {
+      alert("Failed to delete account");
+    }
+  } catch (error) {
+    console.error("Error deleting account:", error);
+    alert("Error deleting account");
   }
 }
 

--- a/Frontend/components/profile.html
+++ b/Frontend/components/profile.html
@@ -83,5 +83,15 @@
         </div>
       </div>
     </div>
+
+    <div class="delete-account-section mt-5">
+      <button
+        type="button"
+        class="btn btn-danger"
+        onclick="if(confirm('Are you sure you want to delete your account? This action cannot be undone.')) deleteAccount()"
+      >
+        Delete Account
+      </button>
+    </div>
   </div>
 </div>


### PR DESCRIPTION
This pull request introduces a new feature that allows users to delete their accounts. The changes span both backend and frontend components to ensure the functionality is integrated seamlessly.

### Backend Changes:
* Added a new endpoint `deleteUser` to handle account deletion in `Backend/users/urls.py`.
* Implemented the `deleteUser` function in `Backend/users/views.py` to delete user accounts and invalidate all associated tokens.

### Frontend Changes:
* Added a new function `deleteAccount` in `Frontend/assets/js/profile.js` to handle account deletion requests and clear local storage upon success.
* Introduced a "Delete Account" button in `Frontend/components/profile.html` that triggers the `deleteAccount` function with a confirmation prompt.
* Modified the `attachProfileFormListener` function in `Frontend/assets/js/profile.js` to remove an unnecessary call to `renderPage("home")`.