### PR TITLE
feat: add password update functionality and form to user settings

### DIFF
--- a/Backend/users/urls.py
+++ b/Backend/users/urls.py
@@ -11,6 +11,7 @@ urlpatterns = [
     path('settings/', views.getUserSettings, name='get_user_settings'),
     path('profile/', views.getUserProfile, name='get_user_profile'),
     path('profile/update/', views.updateUserProfile, name='update_user_profile'),
+    path('profile/update/password/', views.updateUserPassword, name='update_user_password'),
     path('friends/', views.getFriends, name='get_friends'),
     path('friend/delete/<int:friend_id>/', views.deleteFriend, name='delete_friend'),
     path('invites/', views.getInvites, name='get_invites'),

--- a/Backend/users/views.py
+++ b/Backend/users/views.py
@@ -208,6 +208,42 @@ def updateUserProfile(request):
             {'error': str(e)}, 
             status=status.HTTP_500_INTERNAL_SERVER_ERROR
         )
+    
+@api_view(['PUT'])
+@permission_classes([IsAuthenticated])
+def updateUserPassword(request):
+    try:
+        user = request.user
+        data = request.data
+
+        # Check current password
+        if not user.check_password(data['currPassword']):
+            return Response(
+                {'error': 'Current password is incorrect'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Check if new passwords match
+        if data['newPassword'] != data['confPassword']:
+            return Response(
+                {'error': 'New passwords do not match'}, 
+                status=status.HTTP_400_BAD_REQUEST
+            )
+
+        # Update password
+        user.set_password(data['newPassword'])
+        user.save()
+
+        return Response(
+            {'message': 'Password updated successfully'},
+            status=status.HTTP_200_OK
+        )
+
+    except Exception as e:
+        return Response(
+            {'error': str(e)}, 
+            status=status.HTTP_500_INTERNAL_SERVER_ERROR
+        )
 
 @api_view(['GET'])
 @permission_classes([IsAuthenticated])

--- a/Frontend/assets/js/settings.js
+++ b/Frontend/assets/js/settings.js
@@ -1,11 +1,17 @@
 async function attachSettingsFormListener() {
-  const form = document.getElementById("profile-form");
-  if (!form) {
+  const formUser = document.getElementById("profile-form");
+  if (!formUser) {
     console.error("Profile form not found");
     return;
   }
 
-  form.addEventListener("submit", async (event) => {
+  const formPassword = document.getElementById("password-form");
+  if (!formPassword) {
+    console.error("Password form not found");
+    return;
+  }
+
+  formUser.addEventListener("submit", async (event) => {
     event.preventDefault();
     console.log("📝 Submitting profile form");
     const loadingOverlay = new LoadingOverlay();
@@ -51,6 +57,48 @@ async function attachSettingsFormListener() {
     } catch (error) {
       console.error("❌ Error updating profile:", error);
       displayMessage("Failed to update profile", MessageType.ERROR);
+    } finally {
+      loadingOverlay.hide();
+    }
+  });
+
+  formPassword.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    console.log("📝 Submitting password form");
+    const loadingOverlay = new LoadingOverlay();
+
+    const currPassword = document.getElementById("current-password").value;
+    const newPassword = document.getElementById("new-password").value;
+    const confPassword = document.getElementById("confirm-password").value;
+
+    try {
+      loadingOverlay.show();
+      const response = await fetch(
+        "http://localhost:8000/api/users/profile/update/password/",
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${localStorage.getItem("access")}`,
+          },
+          body: JSON.stringify({
+            currPassword: currPassword,
+            newPassword: newPassword,
+            confPassword: confPassword,
+          }),
+        }
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to update password");
+      }
+
+      // Show success message
+      displayMessage("Password updated successfully", MessageType.SUCCESS);
+      renderElement("overview");
+    } catch (error) {
+      console.error("❌ Password updating:", error);
+      displayMessage("Failed to update password", MessageType.ERROR);
     } finally {
       loadingOverlay.hide();
     }

--- a/Frontend/components/settings.html
+++ b/Frontend/components/settings.html
@@ -3,13 +3,7 @@
   <div class="row mb-4">
     <div class="col-12">
       <div class="d-flex align-items-center">
-        <img
-          src="https://github.com/mdo.png"
-          alt="Profile"
-          class="rounded-circle me-3"
-          width="100"
-          height="100"
-        />
+        <img src="https://github.com/mdo.png" alt="Profile" class="rounded-circle me-3" width="100" height="100" />
         <div>
           <h2 class="mb-0" id="profile-username"></h2>
           <p class="text-muted">
@@ -22,7 +16,7 @@
 
   <!-- Profile Content -->
   <div class="row">
-    <!-- User Info -->
+    <!-- User Info Card -->
     <div class="col-md-6 mb-4">
       <div class="card bg-transparent border-light">
         <div class="card-header">
@@ -48,14 +42,38 @@
       </div>
     </div>
 
-    <div class="delete-account-section mt-5">
-      <button
-        type="button"
-        class="btn btn-danger"
-        onclick="if(confirm('Are you sure you want to delete your account? This action cannot be undone.')) deleteAccount()"
-      >
-        Delete Account
-      </button>
+    <!-- Password Change Card -->
+    <div class="col-md-6 mb-4">
+      <div class="card bg-transparent border-light">
+        <div class="card-header">
+          <h4>Change Password</h4>
+        </div>
+        <div class="card-body">
+          <form id="password-form">
+            <div class="mb-3">
+              <label class="form-label">Current Password</label>
+              <input type="password" class="form-control" id="current-password" required />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">New Password</label>
+              <input type="password" class="form-control" id="new-password" required />
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Confirm New Password</label>
+              <input type="password" class="form-control" id="confirm-password" required />
+            </div>
+            <button type="submit" class="btn btn-primary">Update Password</button>
+          </form>
+        </div>
+      </div>
     </div>
   </div>
+
+  <div class="delete-account-section mt-5">
+    <button type="button" class="btn btn-danger"
+      onclick="if(confirm('Are you sure you want to delete your account? This action cannot be undone.')) deleteAccount()">
+      Delete Account
+    </button>
+  </div>
+</div>
 </div>


### PR DESCRIPTION
This pull request introduces a new feature allowing users to update their passwords. The changes span across the backend and frontend to support this functionality. The most important changes include adding a new API endpoint for updating passwords, updating the frontend to include a password change form, and handling the form submission.

Backend changes:

* [`Backend/users/urls.py`](diffhunk://#diff-bd4b2951f7a456131ee8f5065ece321ded1d41a114b7bb836b458e6fe74c5052R14): Added a new URL path for the `updateUserPassword` view.
* [`Backend/users/views.py`](diffhunk://#diff-22bbc97273d37a31b91302f62e96c937c7fb4dd00c52928fc2d7a367b57178e2R212-R247): Implemented the `updateUserPassword` view function to handle password updates, including validation and error handling.

Frontend changes:

* [`Frontend/assets/js/settings.js`](diffhunk://#diff-03fdc286eb301326d9ae995a6c450db18955b47d0e812a59fb2c72c167fbc331L2-R14): Modified the `attachSettingsFormListener` function to add an event listener for the new password form and handle its submission. [[1]](diffhunk://#diff-03fdc286eb301326d9ae995a6c450db18955b47d0e812a59fb2c72c167fbc331L2-R14) [[2]](diffhunk://#diff-03fdc286eb301326d9ae995a6c450db18955b47d0e812a59fb2c72c167fbc331R64-R105)
* [`Frontend/components/settings.html`](diffhunk://#diff-77c49b87f67a36da431d536c829153e5b49f19954423c631af0f5f948b462f87R45-R74): Added a new card for password change in the settings page, including the necessary form fields and submit button.