### PR TITLE
feat: create default profile image directory and download placeholder…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ up:
 	@if [ ! -d "${HOME}/ft_transcendence/Database/" ]; then \
 		mkdir -p ${HOME}/ft_transcendence/Database/; \
 	fi
+	@if [ ! -d "${HOME}/ft_transcendence/Backend/profile_images/" ]; then \
+		mkdir -p ${HOME}/ft_transcendence/Backend/media/profile_images; \
+	fi
+	wget --output-document=${HOME}/ft_transcendence/Backend/media/profile_images/default.jpg https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png
 	docker-compose up --build
 
 # Stop and remove the Docker containers


### PR DESCRIPTION
This pull request includes a small change to the `Makefile` to ensure the correct directory structure and default profile image are in place for the backend.

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R9-R12): Added commands to create the `Backend/profile_images` directory if it doesn't exist and to download a default profile image to this directory.