### PR TITLE
feat: extend access token lifetime to 90 minutes across authenticatio…

### DIFF
--- a/Backend/API/settings.py
+++ b/Backend/API/settings.py
@@ -177,7 +177,7 @@ CORS_ALLOW_CREDENTIALS = True
 from datetime import timedelta
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=5),
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=90),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=1),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,

--- a/Frontend/assets/js/42.js
+++ b/Frontend/assets/js/42.js
@@ -36,7 +36,7 @@ window.onload = async function() {
             // Store the access token and other data
             localStorage.setItem('access', data.access);
             localStorage.setItem('refresh', data.refresh);
-            const accessTokenExpiry = new Date().getTime() + 10 * 60 * 1000; // 10 minutes for testing
+            const accessTokenExpiry = new Date().getTime() + 90 * 60 * 1000; // 10 minutes for testing
             localStorage.setItem('access_token_expiry', accessTokenExpiry);
             localStorage.setItem('username', data.username);
             localStorage.setItem('email', data.email);

--- a/Frontend/assets/js/login.js
+++ b/Frontend/assets/js/login.js
@@ -32,7 +32,7 @@ async function login(username, password) {
       // Store the tokens and expiration time in localStorage or a cookie
       localStorage.setItem("access", responseData.access);
       localStorage.setItem("refresh", responseData.refresh);
-      const accessTokenExpiry = new Date().getTime() + 10 * 60 * 1000; // 2 minutes for testing
+      const accessTokenExpiry = new Date().getTime() + 90 * 60 * 1000; // 2 minutes for testing
       localStorage.setItem("access_token_expiry", accessTokenExpiry);
       localStorage.setItem("username", username);
       renderPage("home");

--- a/Frontend/assets/js/main.js
+++ b/Frontend/assets/js/main.js
@@ -147,7 +147,7 @@ async function refreshToken() {
     const responseData = await response.json();
     if (response.ok) {
       localStorage.setItem("access", responseData.access);
-      const accessTokenExpiry = new Date().getTime() + 10 * 60 * 1000; // 10 minutes for testing
+      const accessTokenExpiry = new Date().getTime() + 90 * 60 * 1000; // 10 minutes for testing
       console.log(
         "New Access Token Expiry:",
         new Date(accessTokenExpiry).toLocaleString()

--- a/Frontend/assets/js/register.js
+++ b/Frontend/assets/js/register.js
@@ -37,7 +37,7 @@ function attachRegisterFormListener() {
         // Store the tokens and expiration time in localStorage or a cookie
         localStorage.setItem("access", responseData.access);
         localStorage.setItem("refresh", responseData.refresh);
-        const accessTokenExpiry = new Date().getTime() + 10 * 60 * 1000; // 30 minutes
+        const accessTokenExpiry = new Date().getTime() + 90 * 60 * 1000; // 30 minutes
         localStorage.setItem("access_token_expiry", accessTokenExpiry);
         renderPage("home");
       } else if (!response.ok && response.status == 429) {


### PR DESCRIPTION
This pull request includes changes to extend the access token lifetime across both backend and frontend code. The most important changes are as follows:

Backend changes:

* [`Backend/API/settings.py`](diffhunk://#diff-c126f8113a5c86c0d959099f420eb3d0befdec17a7a02ae0294f7685a73a7e99L180-R180): Increased the `ACCESS_TOKEN_LIFETIME` from 5 minutes to 90 minutes.

Frontend changes:

* [`Frontend/assets/js/42.js`](diffhunk://#diff-aee4def0b9c45fa68f6d0572686bdba7606855c38b60ecf9378ddc010a63a350L39-R39): Updated the access token expiry time to 90 minutes in the `window.onload` function.
* [`Frontend/assets/js/login.js`](diffhunk://#diff-a8724fd49f485df4fc6181fb0dd17859e3a18738320637d72ff9564d91924790L35-R35): Changed the access token expiry time to 90 minutes in the `login` function.
* [`Frontend/assets/js/main.js`](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fL150-R150): Adjusted the access token expiry time to 90 minutes in the `refreshToken` function.
* [`Frontend/assets/js/register.js`](diffhunk://#diff-e24fbd59714875d40c5a439b727053c7a801e472fb7a20d98798c412224f6159L40-R40): Set the access token expiry time to 90 minutes in the `attachRegisterFormListener` function.