### PR TITLE
feat: add OAuth functionality to sign-up button

### DIFF
--- a/Frontend/register.html
+++ b/Frontend/register.html
@@ -35,7 +35,7 @@
 				background-color: #008f8f;
 			}
 		</style>
-        <button type="button" class="login-button text-black py-2 px-3 rounded-2 w-100 d-flex align-items-center justify-content-center">
+        <button type="button" class="login-button text-black py-2 px-3 rounded-2 w-100 d-flex align-items-center justify-content-center" onclick="startOAuth()">
             <small>Sign up with</small>&nbsp&nbsp&nbsp;
             <img src="/assets/img/42Logo.png" alt="42 Logo" style="width: 30px; height: 30px; background: transparent;" class="ml-2">
         </button>


### PR DESCRIPTION
This pull request includes a change to the `Frontend/register.html` file to enhance the user experience by adding an OAuth functionality to the sign-up button.

Enhancement to user experience:

* [`Frontend/register.html`](diffhunk://#diff-1dc685b517295f20338673d2411419dc26baf96da7129f97d636083f24b7a4beL38-R38): Added an `onclick` attribute to the sign-up button to trigger the `startOAuth()` function, enabling OAuth sign-up with a 42Porto account.