### PR TITLE
feat: add decline invite functionality and improve message modals

### DIFF
--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -53,6 +53,8 @@ class OnlinePlayersConsumer(WebsocketConsumer):
             self.handle_invite(data)
         elif data['type'] == 'accept_invite':
             self.handle_accept_invite(data)
+        elif data['type'] == 'decline_invite':
+            self.handle_decline_invite(data)
         elif data['type'] == 'player_move':
             self.handle_player_move(data)
         elif data['type'] == 'ready':
@@ -77,6 +79,16 @@ class OnlinePlayersConsumer(WebsocketConsumer):
             "online_players",
             {
                 "type": "accept_invite",
+                "from": data['from'],
+                "to": data['to']
+            }
+        )
+
+    def handle_decline_invite(self, data):
+        async_to_sync(self.channel_layer.group_send)(
+            "online_players",
+            {
+                "type": "decline_invite",
                 "from": data['from'],
                 "to": data['to']
             }
@@ -150,7 +162,10 @@ class OnlinePlayersConsumer(WebsocketConsumer):
                 print("Validation errors:", match_serializer.errors)
         else:
             self.send(text_data=json.dumps(event))
-            
+
+    def decline_invite(self, event):
+        if 'to' in event and event['to'] == self.scope['user'].username:
+            self.send(text_data=json.dumps(event))
 
     def get_channel_name(self, username):
         for channel_name, user in channel_user_map.items():

--- a/Frontend/assets/js/MessageModal.js
+++ b/Frontend/assets/js/MessageModal.js
@@ -3,6 +3,7 @@ const MessageType = {
   ERROR: "error",
   WARNING: "warning",
   INFO: "info",
+  INVITE: "invite",
 };
 
 class MessageModal {
@@ -31,8 +32,10 @@ class MessageModal {
               <div class="modal-content bg-dark text-white border-secondary">
                   <div class="modal-header border-secondary">
                       <h5 class="modal-title ${titleClass}">${title}</h5>
-                      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-                  </div>
+                      ${isError ?
+                      `<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>`
+                      : ''}
+                      </div>
                   <div class="modal-body"></div>
                   ${!isError ? `
                   <div class="modal-footer border-secondary">
@@ -78,7 +81,7 @@ class MessageModal {
     }
     this.bsModal.show();
 
-    if (!this.type === MessageType.ERROR) {
+    if ((this.type === MessageType.INVITE)) {
       let timeLeft = 30;
       timerElement.innerHTML = `Time left: ${timeLeft}s`;
       this.timer = setInterval(() => {

--- a/Frontend/assets/js/MessageModal.js
+++ b/Frontend/assets/js/MessageModal.js
@@ -33,6 +33,11 @@ class MessageModal {
                       <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                   </div>
                   <div class="modal-body"></div>
+                  <div class="modal-footer border-secondary">
+                      <span class="timer"></span>
+                      <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                      <button type="button" class="btn btn-primary">Accept</button>
+                  </div>
               </div>
           </div>
       `;
@@ -40,14 +45,99 @@ class MessageModal {
     document.body.appendChild(modal);
     this.modal = modal;
     this.bsModal = new bootstrap.Modal(modal);
+
+    this.modal.querySelector('.btn-primary').addEventListener('click', () => this.handleAccept());
+    this.modal.querySelector('.btn-secondary').addEventListener('click', () => this.handleCancel());
   }
 
-  show(message) {
+  show(message, title = null) {
     this.modal.querySelector(".modal-body").innerHTML = message;
+    const titleElement = this.modal.querySelector(".modal-title");
+    const footerElement = this.modal.querySelector(".modal-footer");
+    const timerElement = this.modal.querySelector(".timer");
+    if (title) {
+      titleElement.innerHTML = title;
+      titleElement.className = "modal-title"; // Reset class to default
+      if (title === "Invite Sent") {
+        footerElement.querySelector('.btn-primary').style.display = 'none';
+      } else {
+        footerElement.querySelector('.btn-primary').style.display = 'inline-block';
+      }
+    } else {
+      const isSuccess = this.type === "success";
+      titleElement.className = isSuccess ? "modal-title text-success" : "modal-title text-danger";
+      titleElement.innerHTML = isSuccess ? "Success" : "Error";
+      footerElement.querySelector('.btn-primary').style.display = 'inline-block';
+    }
     this.bsModal.show();
+
+    let timeLeft = 30;
+    timerElement.innerHTML = `Time left: ${timeLeft}s`;
+    this.timer = setInterval(() => {
+      timeLeft -= 1;
+      timerElement.innerHTML = `Time left: ${timeLeft}s`;
+      if (timeLeft <= 0) {
+        clearInterval(this.timer);
+        this.resolve(false);
+        this.hide();
+      }
+    }, 1000);
+
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+    });
   }
 
   hide() {
     this.bsModal.hide();
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  handleAccept() {
+    this.resolve(true);
+    this.hide();
+  }
+
+  handleCancel() {
+    this.resolve(false);
+    this.hide();
+  }
+
+}
+
+class DeclineModal extends MessageModal {
+  createModal() {
+    const modal = document.createElement("div");
+    modal.className = "modal fade";
+    modal.setAttribute("tabindex", "-1");
+
+    modal.innerHTML = `
+          <div class="modal-dialog modal-dialog-centered">
+              <div class="modal-content bg-dark text-white border-secondary">
+                  <div class="modal-header border-secondary">
+                      <h5 class="modal-title text-danger">Invite Rejected</h5>
+                      <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
+                  </div>
+                  <div class="modal-body"></div>
+                  <div class="modal-footer border-secondary">
+                      <button type="button" class="btn btn-primary" data-bs-dismiss="modal">OK</button>
+                  </div>
+              </div>
+          </div>
+      `;
+
+    document.body.appendChild(modal);
+    this.modal = modal;
+    this.bsModal = new bootstrap.Modal(modal);
+
+    this.modal.querySelector('.btn-primary').addEventListener('click', () => this.hide());
+  }
+
+  show(message, title = null) {
+    this.modal.querySelector(".modal-body").innerHTML = message;
+    this.bsModal.show();
   }
 }

--- a/Frontend/assets/js/MessageModal.js
+++ b/Frontend/assets/js/MessageModal.js
@@ -22,6 +22,7 @@ class MessageModal {
     modal.setAttribute("tabindex", "-1");
 
     const isSuccess = this.type === "success";
+    const isError = this.type === "error";
     const titleClass = isSuccess ? "text-success" : "text-danger";
     const title = isSuccess ? "Success" : "Error";
 
@@ -33,11 +34,12 @@ class MessageModal {
                       <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
                   </div>
                   <div class="modal-body"></div>
+                  ${!isError ? `
                   <div class="modal-footer border-secondary">
                       <span class="timer"></span>
                       <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
                       <button type="button" class="btn btn-primary">Accept</button>
-                  </div>
+                  </div>` : ''}
               </div>
           </div>
       `;
@@ -46,8 +48,10 @@ class MessageModal {
     this.modal = modal;
     this.bsModal = new bootstrap.Modal(modal);
 
-    this.modal.querySelector('.btn-primary').addEventListener('click', () => this.handleAccept());
-    this.modal.querySelector('.btn-secondary').addEventListener('click', () => this.handleCancel());
+    if (!isError) { 
+      this.modal.querySelector('.btn-primary').addEventListener('click', () => this.handleAccept());
+      this.modal.querySelector('.btn-secondary').addEventListener('click', () => this.handleCancel());
+    }
   }
 
   show(message, title = null) {
@@ -65,23 +69,28 @@ class MessageModal {
       }
     } else {
       const isSuccess = this.type === "success";
+      const isError = this.type === "error";
       titleElement.className = isSuccess ? "modal-title text-success" : "modal-title text-danger";
       titleElement.innerHTML = isSuccess ? "Success" : "Error";
-      footerElement.querySelector('.btn-primary').style.display = 'inline-block';
+      if (!isError) {
+        footerElement.querySelector('.btn-primary').style.display = 'inline-block';
+      }
     }
     this.bsModal.show();
 
-    let timeLeft = 30;
-    timerElement.innerHTML = `Time left: ${timeLeft}s`;
-    this.timer = setInterval(() => {
-      timeLeft -= 1;
+    if (!this.type === MessageType.ERROR) {
+      let timeLeft = 30;
       timerElement.innerHTML = `Time left: ${timeLeft}s`;
-      if (timeLeft <= 0) {
-        clearInterval(this.timer);
-        this.resolve(false);
-        this.hide();
-      }
-    }, 1000);
+      this.timer = setInterval(() => {
+        timeLeft -= 1;
+        timerElement.innerHTML = `Time left: ${timeLeft}s`;
+        if (timeLeft <= 0) {
+          clearInterval(this.timer);
+          this.resolve(false);
+          this.hide();
+        }
+      }, 1000);
+    }
 
     return new Promise((resolve) => {
       this.resolve = resolve;

--- a/Frontend/assets/js/lobby.js
+++ b/Frontend/assets/js/lobby.js
@@ -13,8 +13,8 @@ function lobbyLoad() {
     );
   else socket.send(JSON.stringify({ type: "lobby" }));
 
-  waitingModal = new MessageModal(MessageType.INFO);
-  messageModal = new MessageModal(MessageType.INFO);
+  waitingModal = new MessageModal(MessageType.INVITE);
+  messageModal = new MessageModal(MessageType.INVITE);
   declineModal = new DeclineModal(MessageType.INFO);
 
   socket.onmessage = function (event) {

--- a/Frontend/assets/js/lobby.js
+++ b/Frontend/assets/js/lobby.js
@@ -13,6 +13,10 @@ function lobbyLoad() {
     );
   else socket.send(JSON.stringify({ type: "lobby" }));
 
+  waitingModal = new MessageModal(MessageType.INFO);
+  messageModal = new MessageModal(MessageType.INFO);
+  declineModal = new DeclineModal(MessageType.INFO);
+
   socket.onmessage = function (event) {
     data = JSON.parse(event.data);
     console.log("WebSocket message received:", data); // Debugging line
@@ -73,23 +77,53 @@ function lobbyLoad() {
               to: username,
             })
           );
+          waitingModal.show(`Waiting for ${username} to accept your game invite...`, "Invite Sent").then((accept) => {
+            if (!accept) {
+              socket.send(
+                JSON.stringify({
+                  type: "decline_invite",
+                  from: currentUser,
+                  to: username,
+                })
+              );
+              //declineModal.show(`Your game invite to ${username} was rejected.`, "Invite Rejected");
+            }
+          });
         });
       });
     } else if (data.type === "invite") {
-      const accept = confirm(
-        `${data.from} has invited you to play a game. Do you accept?`
-      );
-      if (accept) {
-        socket.send(
-          JSON.stringify({
-            type: "accept_invite",
-            from: currentUser,
-            to: data.from,
-          })
-        );
-        console.log("Game started with:", data.from);
-      }
+      messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
+        if (accept) {
+          // User accepted the invitation
+          socket.send(
+            JSON.stringify({
+              type: "accept_invite",
+              from: currentUser,
+              to: data.from,
+            })
+          );
+          console.log("Game started with:", data.from);
+        } else {
+          // User declined the invitation
+          socket.send(
+            JSON.stringify({
+              type: "decline_invite",
+              from: currentUser,
+              to: data.from,
+            })
+          );
+        }
+      });
+    } else if (data.type === "decline_invite"){
+        waitingModal.hide();
+        messageModal.hide();
+        if (data.to === currentUser)
+          declineModal.show(`Game invite rejected.`, "Invite Rejected");
+
+      console.log("Invite declined by:", data.from);
     } else if (data.type === "start_game") {
+        waitingModal.hide();
+      console.log("Game started with:", data.from);
       renderPage("pong");
     } else if (data.type === "close_connection") socket.close();
   };


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend to support the handling of declined game invites. The most important changes include adding new methods to handle declined invites in the backend and updating the frontend to provide a better user experience with modals for accepting or declining invites.

### Backend Changes:
* Added `handle_decline_invite` method to manage the decline invite action and notify relevant users (`Backend/users/consumers.py`).
* Added `decline_invite` method to send a decline invite event to the appropriate user (`Backend/users/consumers.py`).
* Updated `receive` method to handle the new `decline_invite` action (`Backend/users/consumers.py`).

### Frontend Changes:
* Enhanced `MessageModal` class to include a footer with accept and cancel buttons, and a timer that automatically declines the invite if it expires (`Frontend/assets/js/MessageModal.js`).
* Introduced `DeclineModal` class to display a modal when an invite is declined (`Frontend/assets/js/MessageModal.js`).
* Updated `lobbyLoad` function to use the new modals for handling game invites and their responses (`Frontend/assets/js/lobby.js`). [[1]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eR16-R19) [[2]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eR80-R97) [[3]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eR106-R126)