### PR TITLE
Fix countplayers bug

### DIFF
--- a/Backend/matches/views.py
+++ b/Backend/matches/views.py
@@ -32,8 +32,8 @@ def getRecentMatches(request):
          # Get most active players
         player_stats = SiteUser.objects.annotate(
             matches_played=Count('matches_as_player1') + Count('matches_as_player2'),
-            tournaments_played=Count('tournament_entries')  # Changed from tournament_players
-        ).order_by('-matches_played')[:5]
+            tournaments_played=Count('tournament_entries')
+        ).order_by('-matches_played')[:10]
         
         data = {
             'recent_matches': matches.values(

--- a/Backend/matches/views.py
+++ b/Backend/matches/views.py
@@ -52,6 +52,8 @@ def getRecentMatches(request):
                 'created_at',
                 'status',
                 'winner__username'
+            ).annotate(
+                player_count=Count('players')
             ),
             'overview_stats': {
                 'total_matches': total_matches,

--- a/Backend/tournaments/models.py
+++ b/Backend/tournaments/models.py
@@ -20,6 +20,9 @@ class Tournament(models.Model):
     finished_at = models.DateTimeField(null=True, blank=True)
     winner = models.ForeignKey(SiteUser, on_delete=models.SET_NULL, null=True, related_name='tournaments_won')
 
+    def get_player_count(self):
+        return self.players.filter(status='accepted').count()
+    
     class Meta:
         ordering = ['-created_at']
 

--- a/Frontend/assets/js/matches.js
+++ b/Frontend/assets/js/matches.js
@@ -44,8 +44,8 @@ async function loadMatches() {
               }</td>
               <td>${
                 match.player1__username === data.current_user
-                  ? match.player1_score + "/" + match.player2_score
-                  : match.player2_score + "/" + match.player1_score
+                  ? match.player1_score + " - " + match.player2_score
+                  : match.player2_score + " - " + match.player1_score
               }</td>
               <td>${
                 match.winner__username
@@ -80,8 +80,12 @@ async function loadMatches() {
             }</td>
             <td>${
               match.match__player1__username === data.current_user
-                ? match.match__player2_score
-                : match.match__player2_score + "/" + match.match__player1_score
+                ? match.match__player1_score +
+                  " - " +
+                  match.match__player2_score
+                : match.match__player2_score +
+                  " - " +
+                  match.match__player1_score
             }</td>
             <td>${
               match.match__winner__username

--- a/Frontend/assets/js/overview.js
+++ b/Frontend/assets/js/overview.js
@@ -67,7 +67,7 @@ async function loadChart() {
               beginAtZero: true,
               ticks: {
                 color: "white",
-                stepSize: 1,
+                // stepSize: 1,
                 callback: (value) => Math.round(value),
               },
             },

--- a/Frontend/assets/js/overview.js
+++ b/Frontend/assets/js/overview.js
@@ -151,14 +151,14 @@ async function loadChart() {
     tournamentHistory.innerHTML = data.tournament_history
       .map(
         (tournament) => `
-        <tr>
-            <td>${tournament.name}</td>
-            <td>${getStatusBadge(tournament.status)}</td>
-            <td>${tournament.total_players}</td>
-            <td>${new Date(tournament.created_at).toLocaleDateString()}</td>
-            <td>${tournament.winner__username || "Undefined"}</td>
-        </tr>
-    `
+          <tr>
+              <td>${tournament.name}</td>
+              <td>${getStatusBadge(tournament.status)}</td>
+              <td>${tournament.player_count}</td>
+              <td>${new Date(tournament.created_at).toLocaleDateString()}</td>
+              <td>${tournament.winner__username || "Undefined"}</td>
+          </tr>
+      `
       )
       .join("");
   } catch (error) {

--- a/Frontend/assets/js/profile.js
+++ b/Frontend/assets/js/profile.js
@@ -127,8 +127,8 @@ async function loadProfileData() {
               }</td>
               <td>${
                 match.player1__username === data.username
-                  ? match.player1_score + "/" + match.player2_score
-                  : match.player2_score + "/" + match.player1_score
+                  ? match.player1_score + " - " + match.player2_score
+                  : match.player2_score + " - " + match.player1_score
               }</td>
               <td>${
                 match.winner__username
@@ -297,8 +297,8 @@ async function viewProfile(username) {
               }</td>
               <td>${
                 match.player1__username === data.username
-                  ? match.player1_score + "-" + match.player2_score
-                  : match.player2_score + "-" + match.player1_score
+                  ? match.player1_score + " - " + match.player2_score
+                  : match.player2_score + " - " + match.player1_score
               }</td>
               <td>${
                 match.winner__username


### PR DESCRIPTION
This pull request includes several changes to both the backend and frontend components of the application, focusing on enhancing the display of match and tournament data and improving the user interface.

### Backend Changes:
* [`Backend/matches/views.py`](diffhunk://#diff-c5d13bdd928aa2439784c0621570d7f91999380ae5ce79aadd572e6f5f94336fL35-R36): Increased the number of most active players displayed from 5 to 10 and added a `player_count` annotation to recent matches. [[1]](diffhunk://#diff-c5d13bdd928aa2439784c0621570d7f91999380ae5ce79aadd572e6f5f94336fL35-R36) [[2]](diffhunk://#diff-c5d13bdd928aa2439784c0621570d7f91999380ae5ce79aadd572e6f5f94336fR55-R56)
* [`Backend/tournaments/models.py`](diffhunk://#diff-9f886384bce38d8020b62c37a98a6a166094f0f23c00de09809b0d1f86ba854eR23-R25): Added a `get_player_count` method to the `Tournament` model to count the number of accepted players.

### Frontend Changes:
* [`Frontend/assets/js/matches.js`](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL47-R48): Modified the display format of match scores to use " - " instead of "/". [[1]](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL47-R48) [[2]](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL83-R88)
* [`Frontend/assets/js/overview.js`](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL70-R70): Changed the `loadChart` function to remove the `stepSize` setting for ticks and updated the tournament player count display. [[1]](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL70-R70) [[2]](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL157-R157)
* [`Frontend/assets/js/profile.js`](diffhunk://#diff-26ea547b4f0934f98c9d4072b09ea9444ffa8d6a1e4a2e326424fc63956a8f92L130-R131): Adjusted the match score display format to use " - " instead of "/".