### PR TITLE
feat: make tournament names clickable to load tournament brackets in …

### DIFF
--- a/Frontend/assets/js/overview.js
+++ b/Frontend/assets/js/overview.js
@@ -160,7 +160,7 @@ async function loadChart() {
         .map(
           (tournament) => `
           <tr>
-              <td>${tournament.name}</td>
+              <td onclick="renderElement('tournamentBracket'); loadTournamentBracket(${tournament.id})">${tournament.name}</td>
               <td>${getStatusBadge(tournament.status)}</td>
               <td>${tournament.player_count}</td>
               <td>${new Date(tournament.created_at).toLocaleDateString()}</td>

--- a/Frontend/assets/js/profile.js
+++ b/Frontend/assets/js/profile.js
@@ -143,7 +143,7 @@ function loadProfileData(data) {
       .map(
         (tournament) => `
     <tr>
-      <td>${new Date(tournament.date).toLocaleDateString()}</td>
+      <td onclick="renderElement('tournamentBracket'); loadTournamentBracket(${tournament.id})">${new Date(tournament.date).toLocaleDateString()}</td>
       <td>${tournament.name}</td>
       <td>${tournament.position}</td>
       <td>${tournament.total_players}</td>


### PR DESCRIPTION
This pull request includes updates to enhance the interactivity of tournament table rows in the `overview.js` and `profile.js` files. The changes add an `onclick` event to table cells to render the tournament bracket when a user clicks on the tournament name or date.

Enhancements to interactivity:

* [`Frontend/assets/js/overview.js`](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL163-R163): Added an `onclick` event to the tournament name cell to render the tournament bracket and load the tournament bracket data when clicked.
* [`Frontend/assets/js/profile.js`](diffhunk://#diff-26ea547b4f0934f98c9d4072b09ea9444ffa8d6a1e4a2e326424fc63956a8f92L146-R146): Added an `onclick` event to the tournament date cell to render the tournament bracket and load the tournament bracket data when clicked.…overview and profile