### PR TITLE
feat: implement random game handling and ready state in websocket com…

### DIFF
--- a/Frontend/assets/js/MessageModal.js
+++ b/Frontend/assets/js/MessageModal.js
@@ -5,6 +5,7 @@ const MessageType = {
   INFO: "info",
   INVITE: "invite",
   AWAIT: "await",
+  READY: "ready"
 };
 
 class MessageModal {
@@ -34,7 +35,7 @@ class MessageModal {
               <div class="modal-content bg-dark text-white border-secondary">
                   <div class="modal-header border-secondary">
                       <h5 class="modal-title ${titleClass}">${title}</h5>
-                      ${isError || isAwait ?
+                      ${isError || isAwait || isSuccess ?
                       `<button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>`
                       : ''}
                       </div>
@@ -58,11 +59,18 @@ class MessageModal {
       this.modal.querySelector('.btn-secondary').addEventListener('click', () => this.handleCancel());
     }
 
-    this.modal.addEventListener('hide.bs.modal', () => {
-      if (this.type === MessageType.INVITE || this.type === MessageType.AWAIT) {
-        this.resolve(false);
-      }
-    });
+    // if (isAwait)
+    //   socket.addEventListener('message', function(event) {
+    //     const data = JSON.parse(event.data);
+    //     if (data.type === 'random_game') {
+    //         awaitModal.hide();
+    //   }
+    // });
+    // this.modal.addEventListener('hide.bs.modal', () => {
+    //   if (this.type === MessageType.INVITE || this.type === MessageType.AWAIT) {
+    //     this.resolve(false);
+    //   }
+    // });
   }
 
   show(message, title = null) {
@@ -85,7 +93,7 @@ class MessageModal {
       const isError = this.type === "error";
       titleElement.className = isSuccess ? "modal-title text-success" : "modal-title text-danger";
       titleElement.innerHTML = isSuccess ? "Success" : "Error";
-      if (!isError) {
+      if (!isError && !isSuccess) {
         footerElement.querySelector('.btn-primary').style.display = 'inline-block';
       }
     }

--- a/Frontend/assets/js/newgame.js
+++ b/Frontend/assets/js/newgame.js
@@ -14,15 +14,49 @@ function waitgame() {
         );
 
         awaitModal = new MessageModal(MessageType.AWAIT);
+        readyModal = new MessageModal(MessageType.READY);
+
         awaitModal.show(`Waiting for other player to join...`, "Awaiting").then((accept) => {
+            
             if (!accept) {
                 socket.send(
                     JSON.stringify({
-                    type: "close_await",
-                    from: currentUser,
+                        type: "close_await",
+                        from: currentUser,
                     })
                 );
                 renderElement('overview');
+            }
+            else if (accept) {
+                readyModal.show(`Playing against ${data.opponent}`, "Ready?" ).then((accept) => {
+                    if (!accept) {
+                        socket.send(
+                            JSON.stringify({
+                                type: "close_await",
+                                from: currentUser,
+                            })
+                        );
+                        renderElement('overview');
+                    }
+                    else
+                    {
+                        socket.send(
+                            JSON.stringify({
+                                type: 'random_ready',
+                                from: data.from,
+                                game_group: data.game_group,
+                                player: data.player,
+                            })
+                        )
+                    }
+                });
+            }
+        });
+        socket.addEventListener('message', function(event) {
+            const data = JSON.parse(event.data);
+            if (data.type === 'random_game') {
+                awaitModal.hide();
+                awaitModal.resolve(true);
             }
         });
     }

--- a/Frontend/assets/js/pong.js
+++ b/Frontend/assets/js/pong.js
@@ -85,6 +85,7 @@ function resetValues() {
 
 function startGame(gameGroup, socket) {
         resetValues();
+        
         if (data['player'] === "player1")
         {
             isHost = true;
@@ -100,7 +101,6 @@ function startGame(gameGroup, socket) {
         initializeGame(socket, gameGroup, actualPlayer);
         socket.onmessage = async function(event) {
             const data = JSON.parse(event.data);
-            console.log("Game message received:", data); // Debugging line
             
             if (data.type === 'game_update') {
                 player1 = data.player1;
@@ -137,7 +137,7 @@ function initializeGame(socket, gameGroup, actualPlayer) {
     context = board.getContext("2d");
 
     if (!gameRunning) return;
-
+    
     animationFrameId = requestAnimationFrame(() => update(context, socket, gameGroup));
     draw(context);
 
@@ -197,7 +197,7 @@ async function update(context, socket, gameGroup) {
         }
 
     // Draw the updated state
-    
+        console.log(socket);
     // Send game state updates if the current client is the host
         const currentUser = localStorage.getItem("username");
         socket.send(JSON.stringify({


### PR DESCRIPTION
…munication
This pull request includes several changes to both the backend and frontend components of the application to support a new "random game" feature and improve the handling of game states. The most important changes are summarized below:

### Backend Changes:

* Added new variables and functions to manage the state of random games, such as `match_ready`, `handle_ready`, and `random_game` in `Backend/users/consumers.py`. [[1]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623R17) [[2]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L68-R74) [[3]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L316-R361)
* Modified the `handle_waitlist` function to support random games by adding players to groups and updating the game state.
* Commented out the `handle_close_await` function and related code, indicating a shift towards the new random game handling.

### Frontend Changes:

* Updated `MessageType` in `Frontend/assets/js/MessageModal.js` to include a new "READY" type and modified the `MessageModal` class to handle this new type. [[1]](diffhunk://#diff-3de674d35343d517a9638db950a17da770733ec03d1e4791f7bd2342a9a86c79R8) [[2]](diffhunk://#diff-3de674d35343d517a9638db950a17da770733ec03d1e4791f7bd2342a9a86c79L37-R38) [[3]](diffhunk://#diff-3de674d35343d517a9638db950a17da770733ec03d1e4791f7bd2342a9a86c79L61-R73)
* Enhanced the `waitgame` function in `Frontend/assets/js/newgame.js` to show a "Ready?" modal and handle user responses for random games. [[1]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9R17-R20) [[2]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9R30-R60)
* Added debugging lines and minor adjustments in `Frontend/assets/js/pong.js` to improve game state updates and logging. [[1]](diffhunk://#diff-4a585f79826984eb4283b50857ebb41f02c5c5ddc84cbaa437242954f3e01b68R88) [[2]](diffhunk://#diff-4a585f79826984eb4283b50857ebb41f02c5c5ddc84cbaa437242954f3e01b68L103) [[3]](diffhunk://#diff-4a585f79826984eb4283b50857ebb41f02c5c5ddc84cbaa437242954f3e01b68L200-R200)