### PR TITLE
feat: add Grafana dashboards and Prometheus configuration for system …

### DIFF
--- a/Grafana/dashboards/dashboards.json
+++ b/Grafana/dashboards/dashboards.json
@@ -1,0 +1,115 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "graphTooltip": 0,
+  "hideControls": false,
+  "links": [],
+  "panels": [
+    {
+      "title": "CPU Usage",
+      "type": "gauge",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "100 - (avg by (instance) (irate(node_cpu_seconds_total{mode=\"idle\"}[30s])) * 100)",
+          "legendFormat": "CPU %"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "options": {
+        "maxValue": 100,
+        "minValue": 0,
+        "thresholds": [
+          { "color": "green", "value": null },
+          { "color": "yellow", "value": 60 },
+          { "color": "red", "value": 80 }
+        ]
+      }
+    },
+    {
+      "title": "Memory Usage",
+      "type": "graph",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "100 * (1 - ((node_memory_MemAvailable_bytes or node_memory_MemFree_bytes) / node_memory_MemTotal_bytes))",
+          "legendFormat": "Memory %"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "max": 100
+        }
+      ]
+    },
+    {
+      "title": "Disk Usage",
+      "type": "graph",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "100 - ((node_filesystem_avail_bytes{mountpoint=\"/\"} * 100) / node_filesystem_size_bytes{mountpoint=\"/\"})",
+          "legendFormat": "Disk %"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      }
+    },
+    {
+      "title": "Network Traffic",
+      "type": "graph",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "rate(node_network_receive_bytes_total[5m])",
+          "legendFormat": "Received"
+        },
+        {
+          "expr": "rate(node_network_transmit_bytes_total[5m])",
+          "legendFormat": "Transmitted"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "yaxes": [
+        {
+          "format": "bytes"
+        }
+      ]
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 16,
+  "style": "dark",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h"]
+  },
+  "title": "System Monitoring",
+  "version": 1
+}

--- a/Grafana/provisioning/datasources/prometheus.yml
+++ b/Grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ all: up
 
 # Build and run the Docker containers
 up:
-	@if [ ! -d "${HOME}/ft_transcendence/Database/" ]; then \
-		mkdir -p ${HOME}/ft_transcendence/Database/; \
+	@if [ ! -d "${PWD}/Database/" ]; then \
+		mkdir -p ${PWD}/Database/; \
 	fi
-	@if [ ! -d "${HOME}/ft_transcendence/Backend/media/profile_images/" ]; then \
-		mkdir -p ${HOME}/ft_transcendence/Backend/media/profile_images; \
+	@if [ ! -d "${PWD}/Backend/media/profile_images/" ]; then \
+		mkdir -p ${PWD}/Backend/media/profile_images; \
 	fi
-	wget --output-document=${HOME}/ft_transcendence/Backend/media/profile_images/default.jpg https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png
+	wget --output-document=${PWD}/Backend/media/profile_images/default.jpg https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png
 	docker-compose up --build
 
 # Stop and remove the Docker containers

--- a/Prometheus/prometheus.yml
+++ b/Prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+scrape_configs:
+  - job_name: "node"
+    static_configs:
+      - targets: ["node-exporter:9100"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
-version: '3.8'
+version: "3.8"
 
 services:
   backend:
     build: ./Backend
     volumes:
-      - ./Backend:/usr/src/app/
+      - backend_vol:/usr/src/app/
     ports:
       - 8000:8000
     env_file:
@@ -24,23 +24,91 @@ services:
   frontend:
     build: ./Frontend
     volumes:
-      - ./Frontend:/var/www/html
+      - frontend_vol:/var/www/html
     ports:
       - 443:443
     depends_on:
       - db
       - backend
-  
+
   redis:
     image: redis:5
     restart: always
     ports:
       - 6379:6379
 
+  prometheus:
+    image: prom/prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - prometheus_vol:/etc/prometheus
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    restart: always
+
+  node-exporter:
+    image: prom/node-exporter
+    container_name: node-exporter
+    ports:
+      - "9100:9100"
+    restart: always
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    env_file:
+      - ./.env
+    volumes:
+      - grafana_dash_vol:/var/lib/grafana/dashboards
+      - grafana_pro_vol:/etc/grafana/provisioning
+    restart: always
+
 volumes:
   pgdata:
     driver: local
     driver_opts:
       type: none
-      device: ${HOME}/ft_transcendence/Database
+      device: ${PWD}/Database
+      o: bind
+  frontend_vol:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PWD}/Frontend
+      o: bind
+  backend_vol:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PWD}/Backend
+      o: bind
+  prometheus_vol:
+    driver: local
+    driver_opts:
+      type: none
+      device: ${PWD}/Prometheus
+      o: bind
+  grafana_dash_vol:
+    driver: local
+    driver_opts:
+      type: non
+      device: ${PWD}/Grafana/dashboards
+      o: bind
+  grafana_pro_vol:
+    driver: local
+    driver_opts:
+      type: non
+      device: ${PWD}/Grafana/provisioning
       o: bind


### PR DESCRIPTION
This pull request introduces significant enhancements to the monitoring and provisioning setup. The changes include adding Grafana dashboards and Prometheus configuration, updating the `docker-compose.yml` file to include new services, and modifying the `Makefile` to use relative paths instead of absolute paths.

Monitoring and provisioning setup:

* Added a new Grafana dashboard configuration in `Grafana/dashboards/dashboards.json` with panels for CPU, Memory, Disk, and Network Traffic monitoring.
* Added Prometheus data source configuration in `Grafana/provisioning/datasources/prometheus.yml` to connect to the Prometheus service.
* Added Prometheus configuration in `Prometheus/prometheus.yml` to scrape metrics from the `node-exporter`.

Docker Compose updates:

* Updated `docker-compose.yml` to include new services for Prometheus, Node Exporter, and Grafana, along with volume bindings for these services.
* Modified volume mounts in `docker-compose.yml` to use named volumes instead of direct path bindings for backend and frontend services. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L1-R7) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L27-R27)

Makefile changes:

* Updated the `Makefile` to use `${PWD}` for relative paths instead of `${HOME}` for absolute paths, ensuring the correct directories are created and used.…monitoring