### PR TITLE
feat: update WebSocket connection to use WSS and configure Nginx for …

### DIFF
--- a/Frontend/assets/js/lobby.js
+++ b/Frontend/assets/js/lobby.js
@@ -9,7 +9,7 @@ function lobbyLoad() {
   const token = localStorage.getItem("access");
   if (typeof socket === "undefined" || socket.readyState === WebSocket.CLOSED)
     socket = new WebSocket(
-      `ws://${window.location.origin}:8000/ws/users/online-players/?token=${token}`
+      `wss://${window.location.host}/ws/users/online-players/?token=${token}`
     );
   else socket.send(JSON.stringify({ type: "lobby" }));
 

--- a/Frontend/nginx.conf
+++ b/Frontend/nginx.conf
@@ -15,4 +15,15 @@ server {
     location / {
         try_files $uri $uri/ /index.html;
     }
+
+    location /ws/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
 }

--- a/Server/nginx.conf
+++ b/Server/nginx.conf
@@ -13,18 +13,6 @@ server {
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
-    # location /api/ {
-    #     proxy_pass http://backend:8000;
-    #     proxy_set_header Host $host;
-    #     proxy_set_header X-Real-IP $remote_addr;
-    #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    #     proxy_set_header X-Forwarded-Proto $scheme;
-
-    #     proxy_http_version 1.1;
-    #     proxy_set_header Upgrade $http_upgrade;
-    #     proxy_set_header Connection "upgrade";  
-    # }
-
     location / {
         proxy_pass http://frontend:9000;
         proxy_set_header Host $host;
@@ -35,5 +23,17 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";  
+    }
+
+    
+    location /ws/ {
+        proxy_pass http://backend:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - backend_vol:/usr/src/app/
     ports:
       - 8000:8000
+    expose:
+      - 8000
     depends_on:
       - db
       - redis


### PR DESCRIPTION
This pull request includes multiple changes to improve WebSocket handling and configuration in both the frontend and backend of the application. The most important changes include updating WebSocket URLs, modifying NGINX configurations, and adjusting the Docker Compose setup.

### WebSocket Handling Improvements:

* [`Frontend/assets/js/lobby.js`](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eL12-R12): Updated WebSocket URL to use `wss` protocol instead of `ws` for secure connections.

### NGINX Configuration Updates:

* [`Frontend/nginx.conf`](diffhunk://#diff-f96029ed3da9618771acfcda40d6c55b599b946076f6ace836def8fd45ffea70R18-R28): Added a new location block for WebSocket connections to proxy requests to the backend.
* [`Server/nginx.conf`](diffhunk://#diff-6e6927691c0e4cd8736266958811159a503a2bb4da2ac10808ddf2eeb128cb5eL16-L27): Added a new location block for WebSocket connections to proxy requests to the backend, and removed commented-out code for the `/api/` location. [[1]](diffhunk://#diff-6e6927691c0e4cd8736266958811159a503a2bb4da2ac10808ddf2eeb128cb5eL16-L27) [[2]](diffhunk://#diff-6e6927691c0e4cd8736266958811159a503a2bb4da2ac10808ddf2eeb128cb5eR27-R38)

### Docker Compose Adjustments:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R21-R22): Added `expose` directive for the backend service to expose port 8000 internally within the Docker network.…WebSocket proxying