### PR TITLE
fix: update OAuth redirect URI handling to use dynamic origin

### DIFF
--- a/Backend/users/views.py
+++ b/Backend/users/views.py
@@ -559,10 +559,12 @@ def deleteFriend(request, friend_id):
 @permission_classes([])
 def oauth_callback(request):
     try:
-        print(request)
         code = request.data.get('code')
+        redirectURI = request.data.get('redirectURI')
         if not code:
             return Response({'error': 'Authorization code is missing'}, status=status.HTTP_400_BAD_REQUEST)
+        if not redirectURI:
+            return Response({'error': 'RedirectURI is missing'}, status=status.HTTP_400_BAD_REQUEST)
 
         # Exchange authorization code for access token
         token_url = 'https://api.intra.42.fr/oauth/token'
@@ -571,7 +573,7 @@ def oauth_callback(request):
             'client_id': 'u-s4t2ud-a6f40a3d8815d6e54ce1c1ade89e13948ac4e875a56a593543068f6a77e7ddc4',
             'client_secret': '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',
             'code': code,
-            'redirect_uri': 'https://transcendence_brabos/42'
+            'redirect_uri': redirectURI
         }
         response = requests.post(token_url, data=data)
         print(response)

--- a/Frontend/assets/js/42.js
+++ b/Frontend/assets/js/42.js
@@ -1,6 +1,6 @@
 function startOAuth() {
 	const clientId = 'u-s4t2ud-a6f40a3d8815d6e54ce1c1ade89e13948ac4e875a56a593543068f6a77e7ddc4';
-	const redirectUri = encodeURIComponent('https://transcendence_brabos/42');
+	const redirectUri = encodeURIComponent(`${window.location.origin}/42`);
 	const scope = 'public';
 	const responseType = 'code';
 
@@ -13,15 +13,16 @@ function startOAuth() {
 window.onload = async function () {
 	const urlParams = new URLSearchParams(window.location.search);
 	const code = urlParams.get('code');
+	const redirectURI = `${window.location.origin}/42`;
 
 	if (code) {
 		try {
 			const response = await fetch(`${window.location.origin}/api/users/oauth_callback/`, {
-				method: 'POST', 
+				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json'
 				},
-				body: JSON.stringify({ code: code })
+				body: JSON.stringify({ code: code, redirectURI: redirectURI })
 			});
 
 			if (!response.ok) {

--- a/Frontend/nginx.conf
+++ b/Frontend/nginx.conf
@@ -9,7 +9,7 @@
 
 server {
     listen 9000;
-    server_name localhost transcendence_brabos;
+    server_name localhost transcendence;
 
     root /var/www/html;
     location / {

--- a/Server/nginx.conf
+++ b/Server/nginx.conf
@@ -8,7 +8,7 @@ upstream transcendance_frontend {
 
 server {
     listen 443 ssl;
-    server_name localhost transcendence_brabos;
+    server_name localhost transcendence;
     ssl_protocols TLSv1.2 TLSv1.3;
     ssl_certificate /etc/nginx/ssl/nginx.crt;
     ssl_certificate_key /etc/nginx/ssl/nginx.key;


### PR DESCRIPTION
This pull request includes changes to improve the OAuth flow and update server configuration settings. The most important changes include adding a `redirectURI` parameter to the OAuth callback, modifying the frontend to dynamically use the current origin for the redirect URI, and updating server names in the Nginx configuration.

### OAuth Flow Improvements:

* [`Backend/users/views.py`](diffhunk://#diff-22bbc97273d37a31b91302f62e96c937c7fb4dd00c52928fc2d7a367b57178e2L562-R567): Added a `redirectURI` parameter to the OAuth callback to ensure it is included in the token exchange request. [[1]](diffhunk://#diff-22bbc97273d37a31b91302f62e96c937c7fb4dd00c52928fc2d7a367b57178e2L562-R567) [[2]](diffhunk://#diff-22bbc97273d37a31b91302f62e96c937c7fb4dd00c52928fc2d7a367b57178e2L574-R576)
* [`Frontend/assets/js/42.js`](diffhunk://#diff-aee4def0b9c45fa68f6d0572686bdba7606855c38b60ecf9378ddc010a63a350L3-R3): Modified the `startOAuth` function to dynamically use the current origin for the `redirectUri` and included `redirectURI` in the request body when the page loads. [[1]](diffhunk://#diff-aee4def0b9c45fa68f6d0572686bdba7606855c38b60ecf9378ddc010a63a350L3-R3) [[2]](diffhunk://#diff-aee4def0b9c45fa68f6d0572686bdba7606855c38b60ecf9378ddc010a63a350R16) [[3]](diffhunk://#diff-aee4def0b9c45fa68f6d0572686bdba7606855c38b60ecf9378ddc010a63a350L24-R25)

### Server Configuration Updates:

* [`Frontend/nginx.conf`](diffhunk://#diff-f96029ed3da9618771acfcda40d6c55b599b946076f6ace836def8fd45ffea70L12-R12): Updated the server name from `transcendence_brabos` to `transcendence` for both the HTTP and HTTPS servers. [[1]](diffhunk://#diff-f96029ed3da9618771acfcda40d6c55b599b946076f6ace836def8fd45ffea70L12-R12) [[2]](diffhunk://#diff-6e6927691c0e4cd8736266958811159a503a2bb4da2ac10808ddf2eeb128cb5eL11-R11)