### PR TITLE
Solve all socket issues

### DIFF
--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -407,12 +407,10 @@ class OnlinePlayersConsumer(WebsocketConsumer):
             print(match)
             print(data)
             if data['from'] == match.player1.username:
-                print("AQUIII")
                 match.player1_score = 0
                 match.player2_score = 3
                 match.winner = match.player2
             elif data['from'] == match.player2.username:
-                print("AQUIII")
                 match.player1_score = 3
                 match.player2_score = 0
                 match.winner = match.player1

--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -45,7 +45,7 @@ class OnlinePlayersConsumer(WebsocketConsumer):
             print("CONNECTED: ", self.scope['user'])
             channel_user_map[self.channel_name] = self.scope['user']
             self.send_online_players()
-            self.broadcast_online_players()
+            #self.broadcast_online_players()
         else:
             self.close()
 
@@ -88,7 +88,9 @@ class OnlinePlayersConsumer(WebsocketConsumer):
         elif data['type'] == 'accept_invite_tournament_game':
             self.handle_accept_invite_tournament_game(data)
 
-        
+        #friends
+        elif data['type'] == 'update_lobby':
+            self.broadcast_online_players()
         # elif data['type'] == 'random_game':
         #     self.handle_random(data)
         # elif data['type'] == 'close_await':

--- a/Frontend/assets/js/Friends.js
+++ b/Frontend/assets/js/Friends.js
@@ -6,6 +6,7 @@ class FriendSystem {
     this.setupEventListeners();
     this.loadPendingInvites();
     this.loadFriends();
+    socket.send(JSON.stringify({type: "update_lobby"}));
   }
 
   setupEventListeners() {
@@ -29,7 +30,7 @@ class FriendSystem {
     } finally {
       loadingOverlay.hide();
     }
-  }
+  } 
 
   async loadPendingInvites() {
     const loadingOverlay = new LoadingOverlay();
@@ -96,6 +97,7 @@ class FriendSystem {
       this.loadPendingInvites();
       if (action === "accept") {
         this.loadFriends();
+        socket.send(JSON.stringify({type: "update_lobby"}));
       }
     } catch (error) {
       console.error("Error responding to invite:", error);
@@ -120,6 +122,7 @@ class FriendSystem {
       );
       if (response.ok) {
         this.loadFriends();
+        socket.send(JSON.stringify({type: "update_lobby"}));
       }
     } catch (error) {
       console.error("Error removing friend:", error);

--- a/Frontend/assets/js/lobby.js
+++ b/Frontend/assets/js/lobby.js
@@ -38,76 +38,75 @@ function lobbyLoad() {
         }
         friendsData.friends.forEach(friend => {
           friends.push(friend.username);
+        });
           
-          console.log(friends);
           data.players_data.forEach((player) => {
-            if (player.username !== currentUser && friends.includes(player.username) ) {
+            if (player.username !== currentUser && friends.includes(player.username)) {
               const a = document.createElement("a");
               a.href = "#";
               a.className = "list-group-item list-group-item-action py-3 lh-sm";
               a.innerHTML = `
-              <div class="d-flex justify-content-between align-items-center">
-              <div class="d-flex align-items-center">
-              <span>${player.username}</span>
-              <span class="status-indicator rounded-circle bg-success ms-2"
-              style="width: 8px; height: 8px;">
-              </span>
-              </div>
-              <div class="dropdown">
-              <button class="btn btn-link text-white p-0" 
-              data-bs-toggle="dropdown">
-              <i class="bi bi-three-dots-vertical"></i>
-              </button>
-              <ul class="dropdown-menu dropdown-menu-end">
-              <li>
-              <a class="dropdown-item" href="#" 
-              onclick="renderElement('friendProfile'); viewFriendProfile('${player.username}')">
-              <i class="bi bi-person me-2"></i>View Profile
-              </a>
-              </li>
-              <li>
-              <a class="dropdown-item invite-button" href="#" 
-              data-username=${player.username}>
-              <i class="bi bi-controller me-2"></i>Invite to Game
-              </a>
-              </li>
-              </ul>
-              </div>
-              </div>
+                <div class="d-flex justify-content-between align-items-center">
+                  <div class="d-flex align-items-center">
+                    <span>${player.username}</span>
+                    <span class="status-indicator rounded-circle bg-success ms-2"
+                          style="width: 8px; height: 8px;">
+                    </span>
+                  </div>
+                  <div class="dropdown">
+                    <button class="btn btn-link text-white p-0" 
+                            data-bs-toggle="dropdown">
+                      <i class="bi bi-three-dots-vertical"></i>
+                    </button>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                      <li>
+                        <a class="dropdown-item" href="#" 
+                           onclick="renderElement('friendProfile'); viewFriendProfile('${player.username}')">
+                          <i class="bi bi-person me-2"></i>View Profile
+                        </a>
+                      </li>
+                      <li>
+                        <a class="dropdown-item invite-button" href="#" 
+                           data-username=${player.username}>
+                          <i class="bi bi-controller me-2"></i>Invite to Game
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
               `;
-              
+  
               playersList.appendChild(a);
             }
           });
-        });
-      });
-      const inviteButtons = document.querySelectorAll(".invite-button");
-      inviteButtons.forEach((button) => {
-        button.addEventListener("click", function (event) {
-          event.preventDefault();
-          const username = button.getAttribute("data-username");
-          socket.send(
-            JSON.stringify({
-              type: "invite",
-              from: currentUser,
-              to: username,
-            })
-          );
-          waitingModal.show(`Waiting for ${username} to accept your game invite...`, "Invite Sent").then((accept) => {
-            if (!accept) {
+          const inviteButtons = document.querySelectorAll(".invite-button");
+          inviteButtons.forEach((button) => {
+            button.addEventListener("click", function (event) {
+              event.preventDefault();
+              const username = button.getAttribute("data-username");
               socket.send(
                 JSON.stringify({
-                  type: "decline_invite",
+                  type: "invite",
                   from: currentUser,
                   to: username,
                 })
               );
-              //declineModal.show(`Your game invite to ${username} was rejected.`, "Invite Rejected");
-            }
+              waitingModal.show(`Waiting for ${username} to accept your game invite...`, "Invite Sent").then((accept) => {
+                if (!accept) {
+                  socket.send(
+                    JSON.stringify({
+                      type: "decline_invite",
+                      from: currentUser,
+                      to: username,
+                    })
+                  );
+                  //declineModal.show(`Your game invite to ${username} was rejected.`, "Invite Rejected");
+                }
+              });
+            });
           });
-        });
-      }); 
-      // FriendSystem.loadFriends()
+        })
+        .catch(error => console.error('Error fetching friends:', error));
     } else if (data.type === "invite") {
       messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
         if (accept) {
@@ -182,3 +181,4 @@ function lobbyLoad() {
     console.error("WebSocket error:", error);
   };
 }
+

--- a/Frontend/assets/js/lobby.js
+++ b/Frontend/assets/js/lobby.js
@@ -23,7 +23,6 @@ function lobbyLoad() {
 
     if (data.type === "online.players.update") {
       let friends = []
-      // Fetch the list of friends
       fetch(`${window.location.origin}/api/users/get_user_friends/`, {
         method: 'GET',
         headers: {
@@ -33,13 +32,14 @@ function lobbyLoad() {
       })
       .then(response => response.json())
       .then(friendsData => {
+        const playersList = document.getElementById("online-players-list");
+        if (playersList) {
+            playersList.innerHTML = ""; // Clear the list before updating
+        }
         friendsData.friends.forEach(friend => {
           friends.push(friend.username);
           
-          const playersList = document.getElementById("online-players-list");
-          if (playersList) {
-            playersList.innerHTML = ""; // Clear the list before updating
-          }
+          console.log(friends);
           data.players_data.forEach((player) => {
             if (player.username !== currentUser && friends.includes(player.username) ) {
               const a = document.createElement("a");
@@ -106,7 +106,8 @@ function lobbyLoad() {
             }
           });
         });
-      });
+      }); 
+      // FriendSystem.loadFriends()
     } else if (data.type === "invite") {
       messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
         if (accept) {

--- a/Frontend/assets/js/newgame.js
+++ b/Frontend/assets/js/newgame.js
@@ -15,6 +15,7 @@ function waitgame() {
 
         awaitModal = new MessageModal(MessageType.AWAIT);
         readyModal = new MessageModal(MessageType.READY);
+        giveUpModal = new MessageModal( );
 
         awaitModal.show(`Waiting for other player to join...`, "Awaiting").then((accept) => {
             
@@ -34,20 +35,23 @@ function waitgame() {
                             JSON.stringify({
                                 type: "close_await",
                                 from: currentUser,
+                                game_group: data.game_group,
                             })
                         );
+                        giveUpModal.show(`You gave up`, "Loss by forfeit")
                         renderElement('overview');
                     }
                     else
                     {
-                        socket.send(
-                            JSON.stringify({
-                                type: 'random_ready',
-                                from: data.from,
-                                game_group: data.game_group,
-                                player: data.player,
-                            })
-                        )
+                        if (data.type != 'end_game')
+                            socket.send(
+                                JSON.stringify({
+                                    type: 'random_ready',
+                                    from: data.from,
+                                    game_group: data.game_group,
+                                    player: data.player,
+                                })
+                            );
                     }
                 });
             }
@@ -58,6 +62,13 @@ function waitgame() {
                 awaitModal.hide();
                 awaitModal.resolve(true);
             }
+            if (data.type === 'end_game')
+            {
+                readyModal.hide();
+                readyModal.resolve(true);
+                renderElement('overview');
+            }
+
         });
     }
     catch (error) {


### PR DESCRIPTION
This pull request includes several changes to both the backend and frontend parts of the application, focusing on handling game status updates, improving the lobby system, and refining the friend system.

### Backend Changes:

* `Backend/users/consumers.py`: 
  - Commented out `self.broadcast_online_players()` in the `connect` method to prevent broadcasting online players upon connection.
  - Added handling for `update_lobby` and `close_await` message types in the `receive` method.
  - Modified `handle_end_game` to update match status based on player scores.
  - Added `handle_close_await` method to manage game cancellation and update match scores.

### Frontend Changes:

* `Frontend/assets/js/Friends.js`:
  - Added `socket.send` calls to `update_lobby` in the constructor, `respondToInvite`, and `removeFriend` methods to keep the lobby updated with friend status. [[1]](diffhunk://#diff-81fccef092998935f9e626dd4ea71f920b13b37710453ac131f21b485155560bR9) [[2]](diffhunk://#diff-81fccef092998935f9e626dd4ea71f920b13b37710453ac131f21b485155560bR100) [[3]](diffhunk://#diff-81fccef092998935f9e626dd4ea71f920b13b37710453ac131f21b485155560bR125)

* `Frontend/assets/js/lobby.js`:
  - Refactored `lobbyLoad` function to improve fetching and displaying online friends. [[1]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eL26) [[2]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eL36-R42) [[3]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eL82-L83) [[4]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eR108-R109) [[5]](diffhunk://#diff-64f27408badfc861c8df7e20e31546491ea7a82d7fc1888ea5a340a728a70b9eR184)

* `Frontend/assets/js/newgame.js`:
  - Introduced `giveUpModal` for handling game forfeit scenarios and updated the `waitgame` function to manage game status changes and modal displays. [[1]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9R18) [[2]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9R38-R54) [[3]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9R65-R71)