### PR TITLE
Refactor user profile handling to encode profile image in base64 and …

### DIFF
--- a/Backend/users/views.py
+++ b/Backend/users/views.py
@@ -264,10 +264,16 @@ def getFriendProfile(request, username):
         losses = total_matches - wins
         win_rate = (wins / total_matches * 100) if total_matches > 0 else 0
 
+        # Encode profile image in base64
+        profile_image_base64 = None
+        if user.profile_image:
+            with user.profile_image.open('rb') as image_file:
+                profile_image_base64 = base64.b64encode(image_file.read()).decode('utf-8')
+
         profile_data = {
             'username': user.username,
             'created_time': user.created_time,
-            'profile_image': request.build_absolute_uri(user.profile_image.url) if user.profile_image else None,
+            'profile_image': profile_image_base64,
             'stats': {
                 'total_matches': total_matches,
                 'wins': wins,

--- a/Frontend/assets/js/settings.js
+++ b/Frontend/assets/js/settings.js
@@ -18,7 +18,6 @@ async function attachSettingsFormListener() {
 
     const username = document.getElementById("username-input").value;
     const email = document.getElementById("email-input").value;
-    const twoFactorEnabled = document.getElementById("2fa-toggle").checked;
     const profilePictureInput = document.getElementById(
       "profile-picture-input"
     );
@@ -26,7 +25,6 @@ async function attachSettingsFormListener() {
     const formData = new FormData();
     formData.append("username", username);
     formData.append("email", email);
-    formData.append("two_factor_enabled", twoFactorEnabled);
 
     if (profilePictureInput && profilePictureInput.files.length > 0) {
       formData.append("profile_image", profilePictureInput.files[0]);
@@ -60,7 +58,7 @@ async function attachSettingsFormListener() {
 
       // Show success message
       displayMessage("Profile updated successfully", MessageType.SUCCESS);
-      renderElement("overview");
+      renderPage("home");
     } catch (error) {
       console.error("❌ Error updating profile:", error);
       displayMessage("Failed to update profile", MessageType.ERROR);

--- a/Frontend/components/settings.html
+++ b/Frontend/components/settings.html
@@ -64,10 +64,6 @@
 							<label for="profile-picture-input" class="form-label">Profile Picture</label>
 							<input type="file" class="form-control" id="profile-picture-input" />
 						</div>
-						<div class="form-check mb-3">
-							<label for="2fa-toggle" class="form-check-label">Enable 2FA</label>
-							<input type="checkbox" class="form-check-input" id="2fa-toggle" />
-						</div>
 						<button type="submit" class="btn btn-primary">Save Changes</button>
 					</form>
 				</div>

--- a/Frontend/two_fa_enable.html
+++ b/Frontend/two_fa_enable.html
@@ -6,8 +6,8 @@
 
 				<form id="twoFaEnableForm">
 					<div class="mb-3">
-						<label for="qrCodeImage" class="form-label">Scan the QR code with your authenticator
-							app:</label>
+						<h5>Scan the QR code with your authenticator
+							app:</h5>
 						<div class="w-50 mx-auto">
 							<img id="qrCodeImage" class="img-fluid" alt="QR Code" style="max-width: 200px;">
 						</div>

--- a/Frontend/two_fa_verify.html
+++ b/Frontend/two_fa_verify.html
@@ -18,7 +18,7 @@
 							Cancel
 						</button>
 						<button id="disable" type="button" class="btn btn-primary">
-							Disable 2FA
+							Recover 2FA
 						</button>
 					</div>
 				</form>


### PR DESCRIPTION
This pull request includes several changes to both the backend and frontend components of the application. The most important changes involve encoding profile images in base64, removing the two-factor authentication (2FA) toggle from the settings form, and updating various UI elements related to 2FA.

Changes to backend:

* [`Backend/users/views.py`](diffhunk://#diff-22bbc97273d37a31b91302f62e96c937c7fb4dd00c52928fc2d7a367b57178e2R267-R276): Added functionality to encode profile images in base64 format before including them in the profile data.

Changes to frontend:

* [`Frontend/assets/js/settings.js`](diffhunk://#diff-03fdc286eb301326d9ae995a6c450db18955b47d0e812a59fb2c72c167fbc331L21-L29): Removed the 2FA toggle input from the settings form and updated the success message to redirect to the home page instead of the overview page. [[1]](diffhunk://#diff-03fdc286eb301326d9ae995a6c450db18955b47d0e812a59fb2c72c167fbc331L21-L29) [[2]](diffhunk://#diff-03fdc286eb301326d9ae995a6c450db18955b47d0e812a59fb2c72c167fbc331L63-R61)
* [`Frontend/components/settings.html`](diffhunk://#diff-77c49b87f67a36da431d536c829153e5b49f19954423c631af0f5f948b462f87L67-L70): Removed the 2FA toggle input from the settings form UI.
* [`Frontend/two_fa_enable.html`](diffhunk://#diff-21d94026024543cad57660afdbf11ad329876d6dcb0a73a22419486b873d1007L9-R10): Changed the label for scanning the QR code to a heading for better clarity.
* [`Frontend/two_fa_verify.html`](diffhunk://#diff-cad90300534f32f105175dfe4e0ee6601ac9b84280a0b2eaae29d7de199c4973L21-R21): Updated the button label from "Disable 2FA" to "Recover 2FA" for better user understanding.…remove 2FA settings from profile update form