### PR TITLE
Add npm install step for Contracts directory in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ up:
 	@if [ ! -d "${PWD}/Backend/media/profile_images/" ]; then \
 		mkdir -p ${PWD}/Backend/media/profile_images; \
 	fi
+	@if [ ! -d "${PWD}/Contracts/node_modules/" ]; then \
+		cd ${PWD}/Contracts/; \
+		npm install; \
+		cd ..; \
+	fi
 	wget --output-document=${PWD}/Backend/media/profile_images/default.jpg https://cdn.pixabay.com/photo/2015/10/05/22/37/blank-profile-picture-973460_1280.png
 	docker-compose up --build
 


### PR DESCRIPTION
This pull request includes an update to the `Makefile` to ensure that the necessary dependencies for the `Contracts` directory are installed when running the `up` command.

Build process improvement:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R12-R16): Added a check to see if the `node_modules` directory exists in the `Contracts` directory. If it does not exist, the command changes to the `Contracts` directory, runs `npm install` to install the necessary dependencies, and then returns to the original directory.