### PR TITLE
Fix settings problme

### DIFF
--- a/Frontend/assets/js/42.js
+++ b/Frontend/assets/js/42.js
@@ -31,7 +31,6 @@ async function handle42Callback() {
 			}
 
 			const data = await response.json();
-			console.log('OAuth login successful:', data);
 
 			const responseStruct = {
 				access: data.access,

--- a/Frontend/assets/js/MessageModal.js
+++ b/Frontend/assets/js/MessageModal.js
@@ -63,7 +63,7 @@ class MessageModal {
       this.modal.querySelector('.btn-primary').addEventListener('click', () => this.handleAccept());
       this.modal.querySelector('.btn-secondary').addEventListener('click', () => this.handleCancel());
     }
-    if(isAwait)
+    if (isAwait)
       this.modal.querySelector('.btn-close-white').addEventListener('click', () => this.handleCancel());
     // if (isAwait)
     //   socket.addEventListener('message', function(event) {
@@ -150,6 +150,8 @@ class DeclineModal extends MessageModal {
     const modal = document.createElement("div");
     modal.className = "modal fade";
     modal.setAttribute("tabindex", "-1");
+    modal.setAttribute("role", "dialog");
+    modal.setAttribute("aria-modal", "true");
 
     modal.innerHTML = `
           <div class="modal-dialog modal-dialog-centered">
@@ -168,13 +170,17 @@ class DeclineModal extends MessageModal {
 
     document.body.appendChild(modal);
     this.modal = modal;
-    this.bsModal = new bootstrap.Modal(modal);
+    this.bsModal = new bootstrap.Modal(modal, {
+      backdrop: 'static',
+      keyboard: false
+    });
 
     this.modal.querySelector('.btn-primary').addEventListener('click', () => this.hide());
   }
 
   show(message, title = null) {
     this.modal.querySelector(".modal-body").innerHTML = message;
+    this.modal.removeAttribute('aria-hidden');
     this.bsModal.show();
   }
 }

--- a/Frontend/assets/js/overview.js
+++ b/Frontend/assets/js/overview.js
@@ -1,5 +1,20 @@
+let topPlayersChartInstance = null;
+let avgChartInstance = null;
+
 async function loadChart() {
   let data;
+
+  const ctx1 = document.getElementById('topPlayersChart').getContext('2d');
+  const ctx2 = document.getElementById('avgScoresChart').getContext('2d');
+
+  if (topPlayersChartInstance) {
+    topPlayersChartInstance.destroy();
+  }
+
+  if (avgChartInstance) {
+    avgChartInstance.destroy();
+  }
+
   const loadingOverlay = new LoadingOverlay();
   try {
     loadingOverlay.show();
@@ -32,8 +47,7 @@ async function loadChart() {
   });
 
   // Top Players Chart
-  const topPlayersChart = new Chart(
-    document.getElementById("topPlayersChart"),
+  topPlayersChartInstance = new Chart(ctx1,
     {
       type: "bar",
       data: {
@@ -79,8 +93,7 @@ async function loadChart() {
   );
 
   // Average Scores Chart
-  const avgScoresChart = new Chart(
-    document.getElementById("avgScoresChart"),
+  avgChartInstance = new Chart(ctx2,
     {
       type: "doughnut",
       data: {

--- a/Frontend/assets/js/overview.js
+++ b/Frontend/assets/js/overview.js
@@ -1,4 +1,5 @@
 async function loadChart() {
+  let data;
   const loadingOverlay = new LoadingOverlay();
   try {
     loadingOverlay.show();
@@ -6,170 +7,169 @@ async function loadChart() {
     if (!response.ok) {
       throw new Error("Failed to fetch matches data");
     }
-
-    const data = await response.json();
-
-    // Initialize arrays for each day
-    const winsPerDay = Array(7).fill(0);
-    const lossesPerDay = Array(7).fill(0);
-
-    // Process matches to count wins/losses per day
-    data.recent_matches.forEach((match) => {
-      const matchDate = new Date(match.created_at);
-      const dayIndex = matchDate.getDay();
-      const currentUser = localStorage.getItem("username");
-
-      if (match.winner__username === currentUser) {
-        winsPerDay[dayIndex]++;
-      } else {
-        lossesPerDay[dayIndex]++;
-      }
-    });
-
-    // Top Players Chart
-    const topPlayersChart = new Chart(
-      document.getElementById("topPlayersChart"),
-      {
-        type: "bar",
-        data: {
-          labels: data.overview_stats.top_players.map(
-            (player) => player.username
-          ),
-          datasets: [
-            {
-              label: "Matches Played",
-              data: data.overview_stats.top_players.map(
-                (player) => player.matches
-              ),
-              backgroundColor: "rgba(51, 147, 234, 0.4)",
-              borderColor: "rgba(51, 147, 234, 0.8)",
-              borderWidth: 2,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          indexAxis: "y",
-          plugins: {
-            legend: {
-              display: true,
-              labels: { color: "white" },
-            },
-          },
-          scales: {
-            x: {
-              beginAtZero: true,
-              ticks: {
-                color: "white",
-                stepSize: 1,
-                callback: (value) => Math.round(value),
-              },
-            },
-            y: {
-              ticks: { color: "white" },
-            },
-          },
-        },
-      }
-    );
-
-    // Average Scores Chart
-    const avgScoresChart = new Chart(
-      document.getElementById("avgScoresChart"),
-      {
-        type: "doughnut",
-        data: {
-          labels: ["Player 1", "Player 2"],
-          datasets: [
-            {
-              data: [
-                data.overview_stats.average_scores.player1,
-                data.overview_stats.average_scores.player2,
-              ],
-              backgroundColor: [
-                "rgba(51, 147, 234, 0.4)",
-                "rgba(180, 216, 254, 0.4)",
-              ],
-              borderColor: [
-                "rgba(51, 147, 234, 0.8)",
-                "rgba(180, 216, 254, 0.8)",
-              ],
-              borderWidth: 2,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: true,
-          aspectRatio: 2,
-          plugins: {
-            legend: {
-              display: true,
-              labels: { color: "white" },
-            },
-          },
-        },
-      }
-    );
-
-    const getStatusBadge = (status) => {
-      const statusColors = {
-        active: "bg-success",
-        pending: "bg-warning",
-        finished: "bg-secondary",
-        cancelled: "bg-danger",
-      };
-      return `<span class="badge ${statusColors[status.toLowerCase()] || "bg-secondary"
-        }">${status}</span>`;
-    };
-
-    const noTournamentsDiv = document.getElementById("no-tournaments");
-    const noMatchesDiv = document.getElementById("no-matches");
-
-    // Update match history
-    if (data.recent_matches.length !== 0) {
-      noMatchesDiv.classList.add("d-none");
-      const matchHistory = document.getElementById("latest-matches");
-      matchHistory.innerHTML = data.recent_matches
-        .map(
-          (match) => `
-        <tr>
-            <td>${new Date(match.created_at).toLocaleDateString()}</td>
-            <td>${match.player1__username} vs ${match.player2__username}</td>
-            <td>${match.player1_score} - ${match.player2_score}</td>
-            <td>${match.winner__username || ""}</td>
-            <td>${getStatusBadge(match.status)}</td>
-        </tr>
-    `
-        )
-        .join("");
-    } else {
-      noMatchesDiv.classList.remove("d-none");
-    }
-
-    // Update tournament history
-    if (data.tournament_history.length !== 0) {
-      noTournamentsDiv.classList.add("d-none");
-      const tournamentHistory = document.getElementById("latest-tounaments");
-      tournamentHistory.innerHTML = data.tournament_history
-        .map(
-          (tournament) => `
-          <tr>
-              <td onclick="renderElement('tournamentBracket'); loadTournamentBracket(${tournament.id})">${tournament.name}</td>
-              <td>${getStatusBadge(tournament.status)}</td>
-              <td>${tournament.player_count}</td>
-              <td>${new Date(tournament.created_at).toLocaleDateString()}</td>
-              <td>${tournament.winner__username || ""}</td>
-          </tr>
-      `
-        )
-        .join("");
-    } else {
-      noTournamentsDiv.classList.remove("d-none");
-    }
+    data = await response.json();
   } catch (error) {
     displayMessage("Failed to load graphics data", MessageType.ERROR);
+    return;
   } finally {
     loadingOverlay.hide();
+  }
+  // Initialize arrays for each day
+  const winsPerDay = Array(7).fill(0);
+  const lossesPerDay = Array(7).fill(0);
+
+  // Process matches to count wins/losses per day
+  data.recent_matches.forEach((match) => {
+    const matchDate = new Date(match.created_at);
+    const dayIndex = matchDate.getDay();
+    const currentUser = localStorage.getItem("username");
+
+    if (match.winner__username === currentUser) {
+      winsPerDay[dayIndex]++;
+    } else {
+      lossesPerDay[dayIndex]++;
+    }
+  });
+
+  // Top Players Chart
+  const topPlayersChart = new Chart(
+    document.getElementById("topPlayersChart"),
+    {
+      type: "bar",
+      data: {
+        labels: data.overview_stats.top_players.map(
+          (player) => player.username
+        ),
+        datasets: [
+          {
+            label: "Matches Played",
+            data: data.overview_stats.top_players.map(
+              (player) => player.matches
+            ),
+            backgroundColor: "rgba(51, 147, 234, 0.4)",
+            borderColor: "rgba(51, 147, 234, 0.8)",
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        indexAxis: "y",
+        plugins: {
+          legend: {
+            display: true,
+            labels: { color: "white" },
+          },
+        },
+        scales: {
+          x: {
+            beginAtZero: true,
+            ticks: {
+              color: "white",
+              stepSize: 1,
+              callback: (value) => Math.round(value),
+            },
+          },
+          y: {
+            ticks: { color: "white" },
+          },
+        },
+      },
+    }
+  );
+
+  // Average Scores Chart
+  const avgScoresChart = new Chart(
+    document.getElementById("avgScoresChart"),
+    {
+      type: "doughnut",
+      data: {
+        labels: ["Player 1", "Player 2"],
+        datasets: [
+          {
+            data: [
+              data.overview_stats.average_scores.player1,
+              data.overview_stats.average_scores.player2,
+            ],
+            backgroundColor: [
+              "rgba(51, 147, 234, 0.4)",
+              "rgba(180, 216, 254, 0.4)",
+            ],
+            borderColor: [
+              "rgba(51, 147, 234, 0.8)",
+              "rgba(180, 216, 254, 0.8)",
+            ],
+            borderWidth: 2,
+          },
+        ],
+      },
+      options: {
+        responsive: true,
+        maintainAspectRatio: true,
+        aspectRatio: 2,
+        plugins: {
+          legend: {
+            display: true,
+            labels: { color: "white" },
+          },
+        },
+      },
+    }
+  );
+
+  const getStatusBadge = (status) => {
+    const statusColors = {
+      active: "bg-success",
+      pending: "bg-warning",
+      finished: "bg-secondary",
+      cancelled: "bg-danger",
+    };
+    return `<span class="badge ${statusColors[status.toLowerCase()] || "bg-secondary"
+      }">${status}</span>`;
+  };
+
+  const noTournamentsDiv = document.getElementById("no-tournaments");
+  const noMatchesDiv = document.getElementById("no-matches");
+
+  // Update match history
+  if (data.recent_matches.length !== 0) {
+    noMatchesDiv.classList.add("d-none");
+    const matchHistory = document.getElementById("latest-matches");
+    matchHistory.innerHTML = data.recent_matches
+      .map(
+        (match) => `
+      <tr>
+          <td>${new Date(match.created_at).toLocaleDateString()}</td>
+          <td>${match.player1__username} vs ${match.player2__username}</td>
+          <td>${match.player1_score} - ${match.player2_score}</td>
+          <td>${match.winner__username || ""}</td>
+          <td>${getStatusBadge(match.status)}</td>
+      </tr>
+  `
+      )
+      .join("");
+  } else {
+    noMatchesDiv.classList.remove("d-none");
+  }
+
+  // Update tournament history
+  if (data.tournament_history.length !== 0) {
+    noTournamentsDiv.classList.add("d-none");
+    const tournamentHistory = document.getElementById("latest-tounaments");
+    tournamentHistory.innerHTML = data.tournament_history
+      .map(
+        (tournament) => `
+        <tr>
+            <td onclick="renderElement('tournamentBracket'); loadTournamentBracket(${tournament.id})">${tournament.name}</td>
+            <td>${getStatusBadge(tournament.status)}</td>
+            <td>${tournament.player_count}</td>
+            <td>${new Date(tournament.created_at).toLocaleDateString()}</td>
+            <td>${tournament.winner__username || ""}</td>
+        </tr>
+    `
+      )
+      .join("");
+  } else {
+    noTournamentsDiv.classList.remove("d-none");
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
   server:
     ports:
-      - 443:443
+      - 4000:443
     expose:
       - 443
     build: ./Server
@@ -50,8 +50,6 @@ services:
   redis:
     image: redis:5
     restart: always
-    ports:
-      - 6379:6379
 
   prometheus:
     image: prom/prometheus
@@ -65,8 +63,6 @@ services:
 
   alertmanager:
     image: prom/alertmanager
-    ports:
-      - "9093:9093"
     env_file:
       - ./.env
     volumes:
@@ -78,8 +74,6 @@ services:
   node-exporter:
     image: prom/node-exporter
     container_name: node-exporter
-    ports:
-      - "9100:9100"
     restart: always
     volumes:
       - /proc:/host/proc:ro


### PR DESCRIPTION
This pull request includes several changes to improve the frontend functionality and simplify the Docker configuration. The most important changes include modifying modal behavior, enhancing chart handling, and updating Docker service configurations.

### Frontend Improvements:

* [`Frontend/assets/js/MessageModal.js`](diffhunk://#diff-3de674d35343d517a9638db950a17da770733ec03d1e4791f7bd2342a9a86c79R153-R154): Added `role` and `aria-modal` attributes to the modal element and modified the `bootstrap.Modal` initialization to disable backdrop and keyboard interactions. Also, removed the `aria-hidden` attribute when showing the modal. [[1]](diffhunk://#diff-3de674d35343d517a9638db950a17da770733ec03d1e4791f7bd2342a9a86c79R153-R154) [[2]](diffhunk://#diff-3de674d35343d517a9638db950a17da770733ec03d1e4791f7bd2342a9a86c79L171-R183)
* [`Frontend/assets/js/overview.js`](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeR1-R31): Introduced `topPlayersChartInstance` and `avgChartInstance` to manage chart instances and ensure they are destroyed before creating new ones. Improved error handling and loading overlay management. [[1]](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeR1-R31) [[2]](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL30-R50) [[3]](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL77-R96) [[4]](diffhunk://#diff-4b650979cd451cfba133198989d22f09976b1d1137c33b960da59f18f0d20cdeL170-L174)

### Docker Configuration Simplification:

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39-R39): Changed the server port mapping from `443:443` to `4000:443` and removed port mappings for `redis`, `prometheus`, `alertmanager`, and `node-exporter` services to simplify the configuration. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L39-R39) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L53-L54) [[3]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L68-L69) [[4]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L81-L82)