### PR TITLE
Remove USER directive from Contracts Dockerfile

### DIFF
--- a/Contracts/Dockerfile
+++ b/Contracts/Dockerfile
@@ -10,6 +10,4 @@ COPY contracts ./contracts
 COPY scripts ./scripts
 COPY hardhat.config.js .
 
-USER node
-
 ENTRYPOINT ["npx", "hardhat", "run", "scripts/deploy.js", "--network", "sepolia"]


### PR DESCRIPTION
This pull request includes a small change to the `Contracts/Dockerfile` file. The change removes the `USER node` line, which was previously included before the `ENTRYPOINT` instruction.