### PR TITLE
Fix eventlistenerproblm

### DIFF
--- a/Frontend/assets/js/newgame.js
+++ b/Frontend/assets/js/newgame.js
@@ -3,8 +3,8 @@ async function waitgame() {
     const loadingOverlay = new LoadingOverlay();
     const authenticated = await isAuthenticated();
     if (!authenticated) {
-      console.log("User not authenticated, redirecting to login page.");
-      renderPage('login');
+        console.log("User not authenticated, redirecting to login page.");
+        renderPage('login');
     }
 
     try {
@@ -20,7 +20,7 @@ async function waitgame() {
 
         awaitModal = new MessageModal(MessageType.AWAIT);
         readyModal = new MessageModal(MessageType.READY);
-        giveUpModal = new MessageModal( );
+        giveUpModal = new MessageModal();
 
         awaitModal.show(`Waiting for other player to join...`, "Awaiting").then((accept) => {
             if (!accept) {
@@ -43,10 +43,9 @@ async function waitgame() {
                             })
                         );
                         giveUpModal.show(`You gave up`, "Loss by forfeit")
-                        renderElement('overview');
+                        renderPage('home');
                     }
-                    else
-                    {
+                    else {
                         if (data.type != 'end_game')
                             socket.send(
                                 JSON.stringify({
@@ -68,11 +67,10 @@ async function waitgame() {
                 awaitModal.hide();
                 awaitModal.resolve(true);
             }
-            if (data.type === 'end_game')
-            {
+            if (data.type === 'end_game') {
                 readyModal.hide();
                 readyModal.resolve(true);
-                renderElement('overview');
+                renderPage('home');
             }
 
         });

--- a/Frontend/assets/js/pong3d.js
+++ b/Frontend/assets/js/pong3d.js
@@ -141,7 +141,6 @@ class PongGame {
     async handleEndGame() {
         await this.wait(1200);
         this.cleanup();
-        renderPage("home");
     }
 
     wait(ms) {
@@ -656,13 +655,11 @@ class PongGame {
     async handleBeforeUnload(event) {
         this.sendWarningToOpponent();
         this.forfeitGame();
-        renderPage("home");
     }
 
     async handlePopState(event) {
         this.sendWarningToOpponent();
         this.forfeitGame();
-        renderPage("home");
     }
 
     sendWarningToOpponent() {
@@ -687,7 +684,7 @@ class PongGame {
 
     handlePlayerWarning(data) {
         this.ingame_modal = new MessageModal(MessageType.ERROR);
-        this.ingame_modal.show(`${data.user} gave up` , "Warning");
+        this.ingame_modal.show(`${data.user} gave up`, "Warning");
         this.isRunning = false; // Pause the game
     }
 
@@ -792,8 +789,8 @@ class PongGame {
         const now = Date.now();
         if (now - this.lastSentTime > 300) {
             //if (this.player == "player1")
-                this.sendBallPosition();
-                this.lastSentTime = now;
+            this.sendBallPosition();
+            this.lastSentTime = now;
         }
     }
 
@@ -848,6 +845,7 @@ class PongGame {
         window.removeEventListener('beforeunload', this.handleBeforeUnload.bind(this));
         window.removeEventListener('popstate', this.handlePopState.bind(this));
         // Remove other event listeners, stop animations, etc.
+        renderPage("home");
     }
 
     stopGame(winner) {
@@ -865,10 +863,10 @@ class PongGame {
         this.cleanup();
     }
 
-    
+
     forfeitGame() {
         const forfeitingPlayer = this.user === this.player1Name ? "player1" : "player2";
-    
+
         this.socket.send(JSON.stringify({
             type: 'end_game',
             user: localStorage.getItem("username"),

--- a/Frontend/assets/js/pong3d.js
+++ b/Frontend/assets/js/pong3d.js
@@ -28,10 +28,10 @@ class PongGame {
 
 
         // DEFINE PLAYER AND CAMERA
-        this.user = localStorage.getItem("username") 
+        this.user = localStorage.getItem("username")
         this.player = this.user === this.player1Name ? "player1" : "player2";
         this.currentCamera = this.player === "player1" ? "player1Camera" : "player2Camera";
-        
+
         //player stuff
         this.player1 = { position: { y: 0 } };
         this.player2 = { position: { y: 0 } };
@@ -108,9 +108,9 @@ class PongGame {
     }
 
     setupSocketListeners() {
-        this.socket.addEventListener('message',  (event) => {
+        this.socket.addEventListener('message', (event) => {
             const data = JSON.parse(event.data);
-    
+
             if (data.type === 'game_update') {
                 this.targetBallPosition.x = data.ball.x;
                 this.targetBallPosition.y = data.ball.y;
@@ -697,7 +697,7 @@ class PongGame {
 
     updatePaddles() {
         const paddleLimit = this.fieldWidth / 2 - this.paddleLenght / 2; // Limit paddles within field bounds
-    
+
         if (this.currentCamera === "topCamera") {
             // Controls for top view
             if (this.player === "player1") {
@@ -733,11 +733,11 @@ class PongGame {
                 }
             }
         }
-    
+
         // Interpolate paddle positions
         this.leftPaddle.position.y += (this.targetPlayer1Position - this.leftPaddle.position.y) * 0.3;
         this.rightPaddle.position.y += (this.targetPlayer2Position - this.rightPaddle.position.y) * 0.3;
-    
+
         // Send paddle position only if it has changed
         const paddlePosition = this.player === "player1" ? this.leftPaddle.position.y : this.rightPaddle.position.y;
         if (this.lastPlayerPosition[this.player] !== paddlePosition) {
@@ -750,18 +750,18 @@ class PongGame {
         // Update ball position based on its velocity
         this.ball.position.x += this.ballVelocity.x;
         this.ball.position.y += this.ballVelocity.y;
-    
+
         this.goalPosition = (this.fieldLength + 0.4) / 2;
         const fieldTop = this.fieldWidth / 2 - this.ballSize / 2;
         const fieldBottom = -this.fieldWidth / 2 + this.ballSize / 2;
         const fieldLeft = -(this.fieldLength + 0.5) / 2;
         const fieldRight = (this.fieldLength + 0.5) / 2;
-    
+
         // Check for collisions with the top and bottom walls
         if (this.ball.position.y >= fieldTop || this.ball.position.y <= fieldBottom) {
             this.ballVelocity.y *= -1;
         }
-    
+
         // Check for goals
         if (this.ball.position.x >= fieldRight) {
             this.player1Score++;
@@ -774,7 +774,7 @@ class PongGame {
             this.updateScoreboard();
             this.resetBall();
         }
-    
+
         // Check for game over
         if (this.player1Score >= 5 || this.player2Score >= 5) {
             console.log("Game Over!");
@@ -783,11 +783,11 @@ class PongGame {
             else
                 this.stopGame(this.player2Name);
         }
-    
+
         // Check for paddle collisions
         this.checkPaddleCollision(this.leftPaddle);
         this.checkPaddleCollision(this.rightPaddle);
-    
+
         // Throttle sending ball position
         const now = Date.now();
         if (now - this.lastSentTime > 300) {
@@ -844,6 +844,9 @@ class PongGame {
         this.isRunning = false;
         window.removeEventListener("keydown", this.handleKeyDown);
         window.removeEventListener("keyup", this.handleKeyUp);
+        window.removeEventListener("keyup", (e) => (this.keys[e.key] = false));
+        window.removeEventListener('beforeunload', this.handleBeforeUnload.bind(this));
+        window.removeEventListener('popstate', this.handlePopState.bind(this));
         // Remove other event listeners, stop animations, etc.
     }
 


### PR DESCRIPTION
This pull request includes several changes to the `Frontend/assets/js/newgame.js` and `Frontend/assets/js/pong3d.js` files to improve the handling of game state transitions and event listeners. The most important changes are summarized below:

### Game State Transitions:

* [`Frontend/assets/js/newgame.js`](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9L46-R48): Replaced `renderElement('overview')` with `renderPage('home')` in the `waitgame` function to ensure the correct page is rendered when the game ends or is forfeited. [[1]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9L46-R48) [[2]](diffhunk://#diff-2f5730cb107dd56a258a4f631bc983ace235f60da74bff830ec4d3f75cda3cb9L71-R73)

### Event Listener Management:

* [`Frontend/assets/js/pong3d.js`](diffhunk://#diff-34bd4ebaab12108cbe0e100ecb5d7c5c2fb0376a5cadedb14bb1d6a1aadf8b89L144): Removed redundant `renderPage("home")` calls from `handleEndGame`, `handleBeforeUnload`, and `handlePopState` methods. [[1]](diffhunk://#diff-34bd4ebaab12108cbe0e100ecb5d7c5c2fb0376a5cadedb14bb1d6a1aadf8b89L144) [[2]](diffhunk://#diff-34bd4ebaab12108cbe0e100ecb5d7c5c2fb0376a5cadedb14bb1d6a1aadf8b89L659-L665)
* [`Frontend/assets/js/pong3d.js`](diffhunk://#diff-34bd4ebaab12108cbe0e100ecb5d7c5c2fb0376a5cadedb14bb1d6a1aadf8b89R844-R848): Added removal of event listeners for `keyup`, `beforeunload`, and `popstate` events in the `cleanup` method to ensure proper cleanup of resources.