### PR TITLE
refactor: update online players data serialization in WebSocket consumer

### DIFF
--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -3,7 +3,7 @@ from channels.generic.websocket import WebsocketConsumer
 import time
 from asgiref.sync import async_to_sync
 from .models import SiteUser
-
+from .serializers import FriendsSerializer
 from matches.models import Match
 from matches.serializers import MatchSerializer
 from tournaments.models import TournamentMatch
@@ -137,15 +137,19 @@ class OnlinePlayersConsumer(WebsocketConsumer):
         )
 
     def send_online_players(self):
-        players_data = [{"username": user.username} for user in channel_user_map.values()]
+        user = self.scope['user']
+        serializer = FriendsSerializer(user)
+        players_data = serializer.data  # Serialize the data
         data = {
-                "type": "online.players.update",
-                "players_data": players_data,
-            }
+            "type": "online.players.update",
+            "players_data": players_data,
+        }
         self.send(text_data=json.dumps(data))
 
     def broadcast_online_players(self):
-        players_data = [{"username": user.username} for user in channel_user_map.values()]
+        user = self.scope['user']
+        serializer = FriendsSerializer(user)
+        players_data = serializer.data
         async_to_sync(self.channel_layer.group_send)(
             "online_players",
             {

--- a/Frontend/assets/js/Socket.js
+++ b/Frontend/assets/js/Socket.js
@@ -5,7 +5,7 @@ class Socket {
   constructor(token) {
     this.token = token;
     this.connectWebSocket(token);
-    
+
     this.waitingModal = new MessageModal(MessageType.INVITE);
     this.messageModal = new MessageModal(MessageType.INVITE);
     this.declineModal = new DeclineModal(MessageType.INFO);
@@ -13,241 +13,214 @@ class Socket {
 
   async connectWebSocket(token) {
     this.socket = new WebSocket(
-        `wss://${window.location.host}/ws/users/online-players/?token=${token}`
+      `wss://${window.location.host}/ws/users/online-players/?token=${token}`
     );
 
     this.socket.onopen = () => {
-        this.isConnected = true;
+      this.isConnected = true;
     };
 
     this.socket.onclose = async (event) => {
-        // this.isConnected = false;
-        // const newToken = await refreshToken();
-        // this.socket.onopen = NULL;
-        // this.socket.onclose = NULL;
-        // this.socket.onerror = NULL;
-        // this.socket.onmessage = NULL;
-        // if (newToken) {
-        //   this.connectWebSocket(newToken);
-        // } else {
-        //   renderPage('login');
-        // }
-        logout();
+      // this.isConnected = false;
+      // const newToken = await refreshToken();
+      // this.socket.onopen = NULL;
+      // this.socket.onclose = NULL;
+      // this.socket.onerror = NULL;
+      // this.socket.onmessage = NULL;
+      // if (newToken) {
+      //   this.connectWebSocket(newToken);
+      // } else {
+      //   renderPage('login');
+      // }
+      logout();
     };
 
     this.socket.onerror = (error) => {
-        console.error("WebSocket error:", error);
+      console.error("WebSocket error:", error);
     };
 
     this.lobbyLoad(token);
   }
-    
-    async lobbyLoad(token) {
 
-        console.log("pathname:", window.location.pathname);
-        const currentUser = localStorage.getItem("username"); // Assuming you store the username in localStorage
-        console.log("WebSocket user:", currentUser);
+  async lobbyLoad(token) {
 
-        if (typeof this.socket === "undefined" || this.socket.readyState === WebSocket.CLOSED) {
-            this.socket = new WebSocket(
-                `wss://${window.location.host}/ws/users/online-players/?token=${token}`
+    console.log("pathname:", window.location.pathname);
+    const currentUser = localStorage.getItem("username"); // Assuming you store the username in localStorage
+    console.log("WebSocket user:", currentUser);
+
+    if (typeof this.socket === "undefined" || this.socket.readyState === WebSocket.CLOSED) {
+      this.socket = new WebSocket(
+        `wss://${window.location.host}/ws/users/online-players/?token=${token}`
+      );
+      await new Promise((resolve, reject) => {
+        this.socket.onopen = resolve;
+        this.socket.onerror = reject;
+      });
+    } else if (this.socket.readyState === WebSocket.CONNECTING) {
+      await new Promise((resolve, reject) => {
+        this.socket.onopen = resolve;
+        this.socket.onerror = reject;
+      });
+    }
+    else {
+      this.socket.send(JSON.stringify({ type: "lobby" }));
+    }
+
+    this.socket.onmessage = async (event) => {
+      data = JSON.parse(event.data);
+      console.log("WebSocket message received:", data); // Debugging line
+
+      if (data.type === "online.players.update") {
+        const playersList = document.getElementById("online-players-list");
+        if (playersList) {
+          playersList.innerHTML = ""; // Clear the list before updating
+        }
+        if (Array.isArray(data.players_data)) {
+          data.players_data.friends.forEach((friend) => {
+            const a = document.createElement("a");
+            a.href = "#";
+            a.className = "list-group-item list-group-item-action py-3 lh-sm";
+            a.innerHTML = `
+                    <div class="d-flex justify-content-between align-items-center">
+                        <div class="d-flex align-items-center">
+                            <span>${friend.username}</span>
+                            <span class="status-indicator rounded-circle bg-success ms-2"
+                                style="width: 8px; height: 8px;">
+                            </span>
+                        </div>
+                        <div class="dropdown">
+                            <button class="btn btn-link text-white p-0" 
+                                    data-bs-toggle="dropdown">
+                                <i class="bi bi-three-dots-vertical"></i>
+                            </button>
+                            <ul class="dropdown-menu dropdown-menu-end">
+                                <li>
+                                    <a class="dropdown-item" href="#" 
+                                    onclick="renderElement('friendProfile'); viewFriendProfile('${friend.username}')">
+                                        <i class="bi bi-person me-2"></i>View Profile
+                                    </a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item invite-button" href="#" 
+                                    data-username=${friend.username}>
+                                        <i class="bi bi-controller me-2"></i>Invite to Game
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                `;
+            playersList.appendChild(a);
+          });
+        }
+        const inviteButtons = document.querySelectorAll(".invite-button");
+        inviteButtons.forEach((button) => {
+          button.addEventListener("click", (event) => {
+            event.preventDefault();
+            const username = button.getAttribute("data-username");
+            this.socket.send(
+              JSON.stringify({
+                type: "invite",
+                from: currentUser,
+                to: username,
+              })
             );
-            await new Promise((resolve, reject) => {
-                this.socket.onopen = resolve;
-                this.socket.onerror = reject;
-            });
-        } else if (this.socket.readyState === WebSocket.CONNECTING) {
-            await new Promise((resolve, reject) => {
-                this.socket.onopen = resolve;
-                this.socket.onerror = reject;
-            });
-        }
-        else {
-            this.socket.send(JSON.stringify({ type: "lobby" }));
-        } 
-
-        this.socket.onmessage = async (event) => {
-          data = JSON.parse(event.data);
-          // console.log("WebSocket message received:", data); // Debugging line
-      
-          if (data.type === "online.players.update") {
-            let friends = []
-            const playersList = document.getElementById("online-players-list");
-            if (playersList) {
-                playersList.innerHTML = ""; // Clear the list before updating
-            }
-            try {
-              const authenticated = await isAuthenticated();
-              if (!authenticated) {
-                console.log("User not authenticated, redirecting to login page.");
-                renderPage('login');
-              }
-              const response = await fetchWithAuth("/api/users/get_user_friends/");
-              if (!response.ok) {
-                  throw new Error('Failed to fetch friends');
-              }
-              const friendsData = await response.json();
-              if (friendsData.friends) {
-                  const playersList = document.getElementById("online-players-list");
-                  if (playersList) {
-                      playersList.innerHTML = ""; // Clear the list before updating
-                  }
-                  friendsData.friends.forEach(friend => {
-                      friends.push(friend.username);
-                  });
-                  data.players_data.forEach((player) => {
-                      if (player.username !== currentUser && friends.includes(player.username)) {
-                          const a = document.createElement("a");
-                          a.href = "#";
-                          a.className = "list-group-item list-group-item-action py-3 lh-sm";
-                          a.innerHTML = `
-                              <div class="d-flex justify-content-between align-items-center">
-                                  <div class="d-flex align-items-center">
-                                      <span>${player.username}</span>
-                                      <span class="status-indicator rounded-circle bg-success ms-2"
-                                          style="width: 8px; height: 8px;">
-                                      </span>
-                                  </div>
-                                  <div class="dropdown">
-                                      <button class="btn btn-link text-white p-0" 
-                                              data-bs-toggle="dropdown">
-                                          <i class="bi bi-three-dots-vertical"></i>
-                                      </button>
-                                      <ul class="dropdown-menu dropdown-menu-end">
-                                          <li>
-                                              <a class="dropdown-item" href="#" 
-                                              onclick="renderElement('friendProfile'); viewFriendProfile('${player.username}')">
-                                                  <i class="bi bi-person me-2"></i>View Profile
-                                              </a>
-                                          </li>
-                                          <li>
-                                              <a class="dropdown-item invite-button" href="#" 
-                                              data-username=${player.username}>
-                                                  <i class="bi bi-controller me-2"></i>Invite to Game
-                                              </a>
-                                          </li>
-                                      </ul>
-                                  </div>
-                              </div>
-                          `;
-                          playersList.appendChild(a);
-                      }
-                  });
-                  const inviteButtons = document.querySelectorAll(".invite-button");
-                  inviteButtons.forEach((button) => {
-                      button.addEventListener("click", (event) => {
-                          event.preventDefault();
-                          const username = button.getAttribute("data-username");
-                          this.socket.send(
-                              JSON.stringify({
-                                  type: "invite",
-                                  from: currentUser,
-                                  to: username,
-                              })
-                          );
-                          this.waitingModal.show(`Waiting for ${username} to accept your game invite...`, "Invite Sent").then((accept) => {
-                              if (!accept) {
-                                  this.socket.send(
-                                      JSON.stringify({
-                                          type: "decline_invite",
-                                          from: currentUser,
-                                          to: username,
-                                      })
-                                  );
-                                  //this.declineModal.show(`Your game invite to ${username} was rejected.`, "Invite Rejected");
-                              }
-                          });
-                      });
-                  });
-              } else {
-                  console.error('Error: friendsData.friends is undefined');
-              }
-            } catch (error) {
-                console.error('Error fetching friends:', error);
-            }
-          } else if (data.type === "invite") {
-            this.messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
-              if (accept) {
-                // User accepted the invitation
-                this.socket.send(
-                  JSON.stringify({
-                    type: "accept_invite",
-                    from: currentUser,
-                    to: data.from,
-                  })
-                );
-                console.log("Game started with:", data.from);
-              } else {
-                // User declined the invitation
+            this.waitingModal.show(`Waiting for ${username} to accept your game invite...`, "Invite Sent").then((accept) => {
+              if (!accept) {
                 this.socket.send(
                   JSON.stringify({
                     type: "decline_invite",
                     from: currentUser,
-                    to: data.from,
+                    to: username,
                   })
                 );
+                //this.declineModal.show(`Your game invite to ${username} was rejected.`, "Invite Rejected");
               }
             });
-          } else if (data.type === "decline_invite") {
-            this.waitingModal.hide();
-            this.messageModal.hide();
-            if (data.to === currentUser)
-              this.declineModal.show(`Game invite rejected.`, "Invite Rejected");
-      
-            console.log("Invite declined by:", data.from);
-          } else if (data.type === "start_game") {
-            this.waitingModal.hide();
+          });
+        });
+      } else if (data.type === "invite") {
+        this.messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
+          if (accept) {
+            // User accepted the invitation
+            this.socket.send(
+              JSON.stringify({
+                type: "accept_invite",
+                from: currentUser,
+                to: data.from,
+              })
+            );
             console.log("Game started with:", data.from);
-            renderPage("pong");
-          } else if (data.type === "close_connection") {
-            this.socket.close();
-      
-          //TOURNAMENTS
-          } else if (data.type === "invite_tournament_game") {
-            this.messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
-              if (accept) {
-                // User accepted the invitation
-                this.socket.send(
-                  JSON.stringify({
-                    type: "accept_invite_tournament_game",
-                    from: currentUser,
-                    to: data.from,
-                    game: data.game,
-                    player1: data.player1,
-                    player2: data.player2,
-                  })
-                );
-                console.log("Game started with:", data.from);
-              } else {
-                // User declined the invitation
-                this.socket.send(
-                  JSON.stringify({
-                    type: "decline_invite",
-                    from: currentUser,
-                    to: data.from,
-                    game: match.match__id,
-                  })
-                );
-              }
-            });
+          } else {
+            // User declined the invitation
+            this.socket.send(
+              JSON.stringify({
+                type: "decline_invite",
+                from: currentUser,
+                to: data.from,
+              })
+            );
           }
-        };
-    }
+        });
+      } else if (data.type === "decline_invite") {
+        this.waitingModal.hide();
+        this.messageModal.hide();
+        if (data.to === currentUser)
+          this.declineModal.show(`Game invite rejected.`, "Invite Rejected");
 
-    async send(message)
-    {
-        this.socket.send(message);
-    }
+        console.log("Invite declined by:", data.from);
+      } else if (data.type === "start_game") {
+        this.waitingModal.hide();
+        console.log("Game started with:", data.from);
+        renderPage("pong");
+      } else if (data.type === "close_connection") {
+        this.socket.close();
 
-    addEventListener(type, listener) {
-      this.socket.addEventListener(type, listener);
+        //TOURNAMENTS
+      } else if (data.type === "invite_tournament_game") {
+        this.messageModal.show(`${data.from} has invited you to play a game. Do you accept?`, "Invite").then((accept) => {
+          if (accept) {
+            // User accepted the invitation
+            this.socket.send(
+              JSON.stringify({
+                type: "accept_invite_tournament_game",
+                from: currentUser,
+                to: data.from,
+                game: data.game,
+                player1: data.player1,
+                player2: data.player2,
+              })
+            );
+            console.log("Game started with:", data.from);
+          } else {
+            // User declined the invitation
+            this.socket.send(
+              JSON.stringify({
+                type: "decline_invite",
+                from: currentUser,
+                to: data.from,
+                game: match.match__id,
+              })
+            );
+          }
+        });
+      }
+    };
+  }
+
+  async send(message) {
+    this.socket.send(message);
+  }
+
+  addEventListener(type, listener) {
+    this.socket.addEventListener(type, listener);
+  }
+
+  destroy() {
+    if (this.socket) {
+      this.socket.close();
+      this.socket = null;
     }
-    
-    destroy() {
-        if (this.socket) {
-            this.socket.close();
-            this.socket = null;
-        }
-        console.log("Socket connection closed and resources cleaned up.");
-    }
+    console.log("Socket connection closed and resources cleaned up.");
+  }
 }


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend of the application to improve the handling and display of online friends. The most important changes involve updating the serialization of user data and simplifying the frontend logic for displaying online friends.

### Backend Changes:
* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L6-R6): Added import for `FriendsSerializer` and updated the `send_online_players` and `broadcast_online_players` methods to use `FriendsSerializer` for serializing user data. [[1]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L6-R6) [[2]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L140-R152)

### Frontend Changes:
* [`Frontend/assets/js/Socket.js`](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fL71-R86): Simplified the logic for handling the "online.players.update" message by removing redundant authentication checks and fetching of friends data. Updated the code to directly use the serialized friends data received from the backend. [[1]](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fL71-R86) [[2]](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fL119-R105) [[3]](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fL134-R115) [[4]](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fL162-L167) [[5]](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fL237-R211)