### PR TITLE
refactor: improve online players update logic and clean up socket han…

### DIFF
--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -144,22 +144,26 @@ class OnlinePlayersConsumer(WebsocketConsumer):
     def send_online_players(self):
         user = self.scope['user']
         serializer = FriendsSerializer(user)
-        players_data = serializer.data  # Serialize the data
+        friends_data = serializer.data.get('friends', [])
+        online_friends = [friend for friend in friends_data if friend['username'] in [user.username for user in channel_user_map.values()]]  
+
         data = {
             "type": "online.players.update",
-            "players_data": players_data,
+            "players_data": online_friends,
         }
         self.send(text_data=json.dumps(data))
 
     def broadcast_online_players(self):
         user = self.scope['user']
         serializer = FriendsSerializer(user)
-        players_data = serializer.data
+        friends_data = serializer.data.get('friends', [])
+        online_friends = [friend for friend in friends_data if friend['username'] in [user.username for user in channel_user_map.values()]]  
+
         async_to_sync(self.channel_layer.group_send)(
             "online_players",
             {
                 "type": "online.players.update",
-                "players_data": players_data,
+                "players_data": online_friends,
             }
         )
 

--- a/Frontend/assets/js/Socket.js
+++ b/Frontend/assets/js/Socket.js
@@ -71,12 +71,12 @@ class Socket {
       console.log("WebSocket message received:", data); // Debugging line
 
       if (data.type === "online.players.update") {
-        const playersList = document.getElementById("online-players-list");
-        if (playersList) {
-          playersList.innerHTML = ""; // Clear the list before updating
-        }
-        if (data.players_data.friends) {
-          data.players_data.friends.forEach((friend) => {
+        if (data.players_data) {
+          const playersList = document.getElementById("online-players-list");
+          if (playersList) {
+            playersList.innerHTML = ""; // Clear the list before updating
+          }
+          data.players_data.forEach((friend) => {
             const a = document.createElement("a");
             a.href = "#";
             a.className = "list-group-item list-group-item-action py-3 lh-sm";
@@ -215,9 +215,9 @@ class Socket {
   addEventListener(type, listener) {
     this.socket.addEventListener(type, listener);
   }
-      
+
   removeEventListener(type, listener) {
-      this.socket.removeEventListener(type, listener);
+    this.socket.removeEventListener(type, listener);
   }
 
   destroy() {


### PR DESCRIPTION
This pull request includes changes to improve the handling and display of online friends in both the backend and frontend code. The most important changes include modifying the serialization of friends data and updating the frontend logic to properly display the online friends list.

### Backend Updates:
* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L147-R166): Updated the `send_online_players` and `broadcast_online_players` methods to filter and send only online friends instead of all friends.

### Frontend Updates:
* [`Frontend/assets/js/Socket.js`](diffhunk://#diff-984a624f10028281e2bc3d5c8f97ded34b4bbe2b4ee4792ff07018d15ba8663fR74-R79): Modified the WebSocket message handling to update the online friends list correctly, ensuring the list is cleared before updating and iterating over the correct data structure.…dling