### PR TITLE
Add PostgreSQL monitoring dashboards and update Docker Compose config…

### DIFF
--- a/Grafana/dashboards/dashboards.json
+++ b/Grafana/dashboards/dashboards.json
@@ -104,6 +104,44 @@
           "format": "bytes"
         }
       ]
+    },
+    {
+      "title": "PostgreSQL Connections",
+      "type": "graph",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "pg_stat_activity_count{datname='hello_django_dev'}",
+          "legendFormat": "Connections"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 8
+      },
+      "lines": true,
+      "linewidth": 2
+    },
+    {
+      "title": "PostgreSQL Cache Hit Ratio",
+      "type": "graph",
+      "datasource": "Prometheus",
+      "targets": [
+        {
+          "expr": "pg_stat_database_blks_hit{datname='hello_django_dev'} / (pg_stat_database_blks_hit{datname='hello_django_dev'} + pg_stat_database_blks_read{datname='hello_django_dev'})",
+          "legendFormat": "Cache Hit Ratio"
+        }
+      ],
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 8
+      },
+      "lines": true,
+      "linewidth": 2
     }
   ],
   "refresh": "1s",

--- a/Prometheus/prometheus.yml
+++ b/Prometheus/prometheus.yml
@@ -15,3 +15,7 @@ scrape_configs:
   - job_name: "node"
     static_configs:
       - targets: ["node-exporter:9100"]
+
+  - job_name: "postgres-exporter"
+    static_configs:
+      - targets: ["postgres-exporter:9187"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   db:
     image: postgres:15
@@ -16,10 +14,6 @@ services:
     volumes:
       - ./Backend:/usr/src/app/
       - ./Contracts:/usr/src/contracts/
-    ports:
-      - 8000:8000
-    expose:
-      - 8000
     depends_on:
       - db
       - redis
@@ -28,8 +22,6 @@ services:
     build: ./Frontend
     volumes:
       - ./Frontend:/var/www/html
-    expose:
-      - 9000
     depends_on:
       - db
       - backend
@@ -51,14 +43,32 @@ services:
     image: redis:5
     restart: always
 
+  blockchain:
+    build: ./Contracts
+    volumes:
+      - ./Contracts:/usr/src/contracts
+    env_file:
+      - ./.env
+
   prometheus:
     image: prom/prometheus
-    ports:
-      - "9090:9090"
     volumes:
       - ./Prometheus:/etc/prometheus
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
+    restart: always
+
+  grafana:
+    image: grafana/grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+    env_file:
+      - ./.env
+    volumes:
+      - ./Grafana/dashboards:/var/lib/grafana/dashboards
+      - ./Grafana/provisioning:/etc/grafana/provisioning:ro
     restart: always
 
   alertmanager:
@@ -84,22 +94,10 @@ services:
       - "--path.sysfs=/host/sys"
       - "--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)"
 
-  grafana:
-    image: grafana/grafana
-    ports:
-      - "3000:3000"
-    depends_on:
-      - prometheus
+  postgres-exporter:
+    image: wrouesnel/postgres_exporter
     env_file:
       - ./.env
-    volumes:
-      - ./Grafana/dashboards:/var/lib/grafana/dashboards
-      - ./Grafana/provisioning:/etc/grafana/provisioning:ro
     restart: always
-
-  blockchain:
-    build: ./Contracts
-    volumes:
-      - ./Contracts:/usr/src/contracts
-    env_file:
-      - ./.env
+    depends_on:
+      - db


### PR DESCRIPTION
This pull request includes several changes to the configuration files for Grafana, Prometheus, and Docker Compose. The most important changes include adding new Grafana dashboards, updating Prometheus scrape configurations, and modifying Docker Compose services.

### Grafana Dashboard Updates:
* Added new dashboards for PostgreSQL Connections and PostgreSQL Cache Hit Ratio in `Grafana/dashboards/dashboards.json`.

### Prometheus Configuration Updates:
* Added a new job for `postgres-exporter` in the `Prometheus/prometheus.yml` file.

### Docker Compose Updates:
* Removed exposed ports for the backend and frontend services in `docker-compose.yml`. [[1]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L19-L22) [[2]](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L31-L32)
* Added a new `blockchain` service and re-added the `grafana` service with updated configurations in `docker-compose.yml`.
* Replaced the `grafana` service with a `postgres-exporter` service in `docker-compose.yml`.…uration