### PR TITLE
Another one - entering tournament games

### DIFF
--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -169,10 +169,10 @@ class OnlinePlayersConsumer(WebsocketConsumer):
         )
     
     def broadcast_all_online(self):
-        online_friends = user.username for user in channel_user_map.values()
+        players_data = [{"username": user.username} for user in channel_user_map.values()]
         data = {
-            "type": "online.players.update",
-            "players_data": online_friends,
+            "type": "all_online",
+            "players_data": players_data,
         }
         self.send(text_data=json.dumps(data))
 

--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -106,7 +106,7 @@ class OnlinePlayersConsumer(WebsocketConsumer):
 
         #friends
         elif data['type'] == 'update_lobby':
-            self.broadcast_online_players()
+            self.broadcast_all_online()
         # elif data['type'] == 'random_game':
         #     self.handle_random(data)
         elif data['type'] == 'close_await':
@@ -167,6 +167,14 @@ class OnlinePlayersConsumer(WebsocketConsumer):
                 "players_data": online_friends,
             }
         )
+    
+    def broadcast_all_online(self):
+        online_friends = user.username for user in channel_user_map.values()
+        data = {
+            "type": "online.players.update",
+            "players_data": online_friends,
+        }
+        self.send(text_data=json.dumps(data))
 
     def online_players_update(self, event):
         self.send_online_players()

--- a/Frontend/assets/js/matches.js
+++ b/Frontend/assets/js/matches.js
@@ -62,14 +62,16 @@ function renderTournamentMatch(match, currentUser) {
 }
 
 // PLAY TOURNAMENT MATCHES
-function joinMatch(encodedMatch, currentUser) {
+async function joinMatch(encodedMatch, currentUser) {
   const match = JSON.parse(decodeURIComponent(encodedMatch));
   console.log(`Joining match with ID: ${match.match__id}`);
   console.log(`Player1: ${match.match__player1__username}`);
   console.log(`Player2: ${match.match__player2__username}`);
 
   socket.send(JSON.stringify({ type: "update_lobby" }));
+  await wait(500);
   const players = data.players_data.map(player => player.username);
+  console.log(players);
 
   if (players.includes(match.match__player1__username) && players.includes(match.match__player2__username)) {
     console.log("Both players are in the players_data list.");
@@ -77,7 +79,7 @@ function joinMatch(encodedMatch, currentUser) {
     waitingModal = new MessageModal(MessageType.INVITE);
     declineModal = new DeclineModal(MessageType.INFO);
     errorModal = new MessageModal();
-  
+
     socket.send(
       JSON.stringify({
         type: "invite_tournament_game",
@@ -88,7 +90,7 @@ function joinMatch(encodedMatch, currentUser) {
         player2: match.match__player1__username,
       })
     );
-  
+
     waitingModal.show(`Waiting for ${opponent} to accept your game invite...`, "Invite Sent").then((accept) => {
       if (!accept) {
         socket.send(
@@ -104,11 +106,11 @@ function joinMatch(encodedMatch, currentUser) {
     socket.addEventListener('message', function (event) {
       const data = JSON.parse(event.data);
       if (data.type === 'start_game') {
-          waitingModal.hide();
-          waitingModal.resolve(true);
+        waitingModal.hide();
+        waitingModal.resolve(true);
       }
     });
-  
+
   } else {
     console.log("One or both players are not in the players_data list.");
     displayMessage("The other player is missing", "error")


### PR DESCRIPTION
This pull request includes changes to both the backend and frontend codebases to improve the functionality of broadcasting online players and joining tournament matches. The most important changes include updating the method for broadcasting online players and adding an asynchronous delay when joining a match.

Backend updates:

* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L109-R109): Modified the `receive` method to call `broadcast_all_online` instead of `broadcast_online_players` for the 'update_lobby' type.
* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623R171-R178): Added a new method `broadcast_all_online` to send a list of all online players.

Frontend updates:

* [`Frontend/assets/js/matches.js`](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL65-R74): Changed the `joinMatch` function to be asynchronous and added a delay before processing player data.