### PR TITLE
Add user configuration to Prometheus service in Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,7 @@ services:
 
     prometheus:
         image: prom/prometheus
+        user: "${UID}:${GID}"
         volumes:
             - ./Prometheus:/etc/prometheus
             - ./Prometheus/data:/prometheus


### PR DESCRIPTION
This pull request includes a small change to the `docker-compose.yml` file. The change specifies the user and group IDs for the Prometheus service.

* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3R55): Added `user: "${UID}:${GID}"` to the Prometheus service configuration.