### PR TITLE
Add Grafana service configuration to Nginx and update Docker Compose

### DIFF
--- a/Server/nginx.conf
+++ b/Server/nginx.conf
@@ -6,6 +6,11 @@ upstream transcendance_frontend {
     server frontend:9000;
 }
 
+upstream grafana {
+  server grafana:3000;
+}
+
+
 server {
     listen 443 ssl;
     server_name localhost transcendence;
@@ -46,5 +51,17 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /grafana {
+        proxy_pass http://grafana;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade"; 
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,8 +64,6 @@ services:
 
     grafana:
         image: grafana/grafana
-        ports:
-            - "3000:3000"
         depends_on:
             - prometheus
         env_file:


### PR DESCRIPTION
This pull request includes changes to the `nginx` configuration and `docker-compose` file to add support for Grafana. The most important changes include adding a new upstream block for Grafana, configuring a new location block for Grafana, and modifying the Grafana service configuration in the `docker-compose` file.

### Nginx Configuration Changes:

* Added an upstream block for Grafana in `Server/nginx.conf`.
* Configured a new location block for Grafana in `Server/nginx.conf`, including proxy settings and headers.

### Docker-Compose Changes:

* Removed the port mapping for Grafana in `docker-compose.yml` to avoid exposing it directly and rely on the Nginx proxy instead.