### PR TITLE
Redirect to home page using window.location instead of renderPage aft…

### DIFF
--- a/Frontend/assets/js/2fa.js
+++ b/Frontend/assets/js/2fa.js
@@ -150,7 +150,7 @@ async function verifyOtpCode(responseStruct, otpCode) {
 			localStorage.setItem('username', responseStruct.username);
 			localStorage.setItem('email', responseStruct.email);
 			socket = new Socket(responseStruct.access);
-			renderPage("home");
+			window.location.href = `${window.location.origin}/home`;
 		} else {
 			displayMessage("Invalid OTP code", MessageType.ERROR);
 			renderAuthPage("two_fa_verify", responseStruct);
@@ -178,8 +178,7 @@ async function verifyEnableOtpCode(responseStruct, otpCode) {
 			localStorage.setItem('username', responseStruct.username);
 			localStorage.setItem('email', responseStruct.email);
 			socket = new Socket(responseStruct.access);
-
-			renderPage("home");
+			window.location.href = `${window.location.origin}/home`;
 		} else {
 			displayMessage("Invalid OTP code", MessageType.ERROR);
 			renderAuthPage("two_fa_enable", responseStruct);


### PR DESCRIPTION
This pull request includes changes to the `Frontend/assets/js/2fa.js` file to improve the navigation after verifying OTP codes. The main changes involve updating the redirection method to use `window.location.href` instead of the `renderPage` function.

Navigation improvements:

* [`Frontend/assets/js/2fa.js`](diffhunk://#diff-06506b27d5aa2a70e1d5c8bae95ccad9c2fd307aa5207953c84402790f1ecff5L153-R153): Updated the `verifyOtpCode` function to use `window.location.href` for redirecting to the home page after successful OTP verification.
* [`Frontend/assets/js/2fa.js`](diffhunk://#diff-06506b27d5aa2a70e1d5c8bae95ccad9c2fd307aa5207953c84402790f1ecff5L181-R181): Updated the `verifyEnableOtpCode` function to use `window.location.href` for redirecting to the home page after enabling OTP.…er OTP verification