### PR TITLE
Another one

### DIFF
--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -169,10 +169,10 @@ class OnlinePlayersConsumer(WebsocketConsumer):
         )
     
     def broadcast_all_online(self):
-        online_friends = user.username for user in channel_user_map.values()
+        players_data = [{"username": user.username} for user in channel_user_map.values()]
         data = {
-            "type": "online.players.update",
-            "players_data": online_friends,
+            "type": "all_online",
+            "players_data": players_data,
         }
         self.send(text_data=json.dumps(data))
 

--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -450,20 +450,22 @@ class OnlinePlayersConsumer(WebsocketConsumer):
                 users.append(channel_user_map[channel_name])
                 async_to_sync(self.channel_layer.group_discard)(data['game_group'], channel_name)
             del group_channel_map[data['game_group']]
-            user1 = users[0]
-            user2 = users[1]
-
-            try:
-                user1_id = SiteUser.objects.get(username=user1).id
-                user2_id = SiteUser.objects.get(username=user2).id
-
-            except SiteUser.DoesNotExist as e:
-                print(f"Error: {e}")
-
+            
             match_id = group_match_map[data['game_group']]
             match = Match.objects.get(id=match_id)
             if not match:
                 print ("Nao há arroz")
+
+            user1 = match.player1
+            user2 = match.player2
+
+
+            try:
+                user1_id = match.player1.id
+                user2_id = match.player2.id
+
+            except SiteUser.DoesNotExist as e:
+                print(f"Error: {e}")
             match.player1_score = data['player1Score']
             match.player2_score = data ['player2Score']
             if data['player1Score'] > data['player2Score']:
@@ -673,16 +675,16 @@ class OnlinePlayersConsumer(WebsocketConsumer):
                         'from': event['from'],
                         'game_group': game_group_name,
                         'player': 'player1',
-                        'player1': event['from'],
-                        'player2': event['to'],
+                        'player1': event['player1'],
+                        'player2': event['player2'],
                     }))
                     async_to_sync(self.channel_layer.group_send)(game_group_name, {
                         'type': 'start_game',
                         'from': event['from'],
                         'game_group': game_group_name,
                         'player': 'player2',
-                        'player1': event['from'],
-                        'player2': event['to'],
+                        'player1': event['player1'],
+                        'player2': event['player2'],
                     })
                 else:
                     self.send(text_data=json.dumps({
@@ -690,16 +692,16 @@ class OnlinePlayersConsumer(WebsocketConsumer):
                         'from': event['from'],
                         'game_group': game_group_name,
                         'player': 'player2',
-                        'player1': event['to'],
-                        'player2': event['from'],
+                        'player1': event['player1'],
+                        'player2': event['player2'],
                     }))
                     async_to_sync(self.channel_layer.group_send)(game_group_name, {
                         'type': 'start_game',
                         'from': event['from'],
                         'game_group': game_group_name,
                         'player': 'player1',
-                        'player1': event['to'],
-                        'player2': event['from'],
+                        'player1': event['player1'],
+                        'player2': event['player2'],
                     })
             else:
                 print("Match not found.")

--- a/Backend/users/consumers.py
+++ b/Backend/users/consumers.py
@@ -106,7 +106,7 @@ class OnlinePlayersConsumer(WebsocketConsumer):
 
         #friends
         elif data['type'] == 'update_lobby':
-            self.broadcast_online_players()
+            self.broadcast_all_online()
         # elif data['type'] == 'random_game':
         #     self.handle_random(data)
         elif data['type'] == 'close_await':
@@ -167,6 +167,14 @@ class OnlinePlayersConsumer(WebsocketConsumer):
                 "players_data": online_friends,
             }
         )
+    
+    def broadcast_all_online(self):
+        online_friends = user.username for user in channel_user_map.values()
+        data = {
+            "type": "online.players.update",
+            "players_data": online_friends,
+        }
+        self.send(text_data=json.dumps(data))
 
     def online_players_update(self, event):
         self.send_online_players()

--- a/Frontend/assets/js/main.js
+++ b/Frontend/assets/js/main.js
@@ -95,7 +95,6 @@ async function renderPage(page, element) {
 			}
 
 		} else if (page === "pong") {
-			console.log(data);
 			window.removeEventListener("popstate", handlePopState);
 			startGame3d(data, socket);
 		} else if (page === "42") {

--- a/Frontend/assets/js/matches.js
+++ b/Frontend/assets/js/matches.js
@@ -71,7 +71,6 @@ async function joinMatch(encodedMatch, currentUser) {
   socket.send(JSON.stringify({ type: "update_lobby" }));
   await wait(500);
   const players = data.players_data.map(player => player.username);
-  console.log(players);
 
   if (players.includes(match.match__player1__username) && players.includes(match.match__player2__username)) {
     console.log("Both players are in the players_data list.");

--- a/Frontend/assets/js/matches.js
+++ b/Frontend/assets/js/matches.js
@@ -62,14 +62,16 @@ function renderTournamentMatch(match, currentUser) {
 }
 
 // PLAY TOURNAMENT MATCHES
-function joinMatch(encodedMatch, currentUser) {
+async function joinMatch(encodedMatch, currentUser) {
   const match = JSON.parse(decodeURIComponent(encodedMatch));
   console.log(`Joining match with ID: ${match.match__id}`);
   console.log(`Player1: ${match.match__player1__username}`);
   console.log(`Player2: ${match.match__player2__username}`);
 
   socket.send(JSON.stringify({ type: "update_lobby" }));
+  await wait(500);
   const players = data.players_data.map(player => player.username);
+  console.log(players);
 
   if (players.includes(match.match__player1__username) && players.includes(match.match__player2__username)) {
     console.log("Both players are in the players_data list.");
@@ -77,7 +79,7 @@ function joinMatch(encodedMatch, currentUser) {
     waitingModal = new MessageModal(MessageType.INVITE);
     declineModal = new DeclineModal(MessageType.INFO);
     errorModal = new MessageModal();
-  
+
     socket.send(
       JSON.stringify({
         type: "invite_tournament_game",
@@ -88,7 +90,7 @@ function joinMatch(encodedMatch, currentUser) {
         player2: match.match__player1__username,
       })
     );
-  
+
     waitingModal.show(`Waiting for ${opponent} to accept your game invite...`, "Invite Sent").then((accept) => {
       if (!accept) {
         socket.send(
@@ -104,11 +106,11 @@ function joinMatch(encodedMatch, currentUser) {
     socket.addEventListener('message', function (event) {
       const data = JSON.parse(event.data);
       if (data.type === 'start_game') {
-          waitingModal.hide();
-          waitingModal.resolve(true);
+        waitingModal.hide();
+        waitingModal.resolve(true);
       }
     });
-  
+
   } else {
     console.log("One or both players are not in the players_data list.");
     displayMessage("The other player is missing", "error")

--- a/Frontend/assets/js/matches.js
+++ b/Frontend/assets/js/matches.js
@@ -87,7 +87,7 @@ async function joinMatch(encodedMatch, currentUser) {
         to: opponent,
         game: match.match__id,
         player1: match.match__player1__username,
-        player2: match.match__player1__username,
+        player2: match.match__player2__username,
       })
     );
 

--- a/Frontend/assets/js/pong.js
+++ b/Frontend/assets/js/pong.js
@@ -196,7 +196,6 @@ async function update(context, socket, gameGroup) {
         }
 
     // Draw the updated state
-        console.log(socket);
     // Send game state updates if the current client is the host
         const currentUser = localStorage.getItem("username");
         socket.send(JSON.stringify({

--- a/Frontend/assets/js/pong3d-2.js
+++ b/Frontend/assets/js/pong3d-2.js
@@ -756,7 +756,6 @@ class PongGame {
         if (now - this.lastSentTime > 100) {
             this.sendBallPosition();
             this.lastSentTime = now;
-            console.log(now);
         }
     
         

--- a/Frontend/assets/js/pong3d.js
+++ b/Frontend/assets/js/pong3d.js
@@ -110,7 +110,6 @@ class PongGame {
     setupSocketListeners() {
         this.socket.addEventListener('message', (event) => {
             const data = JSON.parse(event.data);
-            console.log(data);
             if (data.type === 'game_update') {
                 this.ball.position.x = data.ball.x;
                 this.ball.position.y = data.ball.y;


### PR DESCRIPTION
This pull request includes several changes across both the backend and frontend codebases to improve functionality and clean up the code. The most important changes involve updating methods for broadcasting player information, handling game data, and fixing player assignment in tournament matches.

### Backend changes:

* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L109-R109): Updated the `receive` method to call `broadcast_all_online` instead of `broadcast_online_players`. Added a new method `broadcast_all_online` to send data of all online players. [[1]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L109-R109) [[2]](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623R171-R178)
* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L445-R468): Modified the `handle_end_game` method to use `match.player1` and `match.player2` directly instead of querying the database again for users.
* [`Backend/users/consumers.py`](diffhunk://#diff-3bec2a38912ddbf9781fc93d438eedd0dd43b9126390ba33e66fac9d00f2b623L668-R704): Fixed the player assignment in the `accept_invite_tournament_game` method to use `event['player1']` and `event['player2']` instead of `event['from']` and `event['to']`.

### Frontend changes:

* [`Frontend/assets/js/matches.js`](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL65-R72): Changed the `joinMatch` function to be asynchronous and added a delay before checking if players are online. Fixed the `player2` assignment in the match data. [[1]](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL65-R72) [[2]](diffhunk://#diff-b9b33d4cc072302fc21be8f0c6091a6ea634de6b0783c0004ee497fa1544996fL88-R89)
* Removed unnecessary `console.log` statements from various JavaScript files to clean up the code. [[1]](diffhunk://#diff-a5e285581fde238bd3446ed1507d9925bdf4ccc1c7e90c727f1f79074b12ac8fL98) [[2]](diffhunk://#diff-4a585f79826984eb4283b50857ebb41f02c5c5ddc84cbaa437242954f3e01b68L199) [[3]](diffhunk://#diff-06da80042333f94d3feb9610c393b1877800b6888f934fde302e33e84a78dcd5L759) [[4]](diffhunk://#diff-34bd4ebaab12108cbe0e100ecb5d7c5c2fb0376a5cadedb14bb1d6a1aadf8b89L113)