### PR TITLE
Refactor renderPage function by removing popstate event listeners and…

### DIFF
--- a/Frontend/assets/js/main.js
+++ b/Frontend/assets/js/main.js
@@ -56,7 +56,6 @@ async function renderPage(page, element) {
 	const loadingOverlay = new LoadingOverlay();
 
 	try {
-		window.addEventListener("popstate", handlePopState);
 		loadingOverlay.show();
 		const screen = document.querySelector(".screen-container");
 
@@ -81,14 +80,12 @@ async function renderPage(page, element) {
 		} else if (page === "register") {
 			attachRegisterFormListener();
 		} else if (page === "home") {
-			if (router.currentPage !== page) {
-				updateUserProfile();
-				load_profile_pic();
-				console.log("Before Load");
-				if (!socket || socket == undefined)
-					socket = new Socket(localStorage.getItem('access'));
-				socket.lobbyLoad(localStorage.getItem('access'));
-			}
+			updateUserProfile();
+			load_profile_pic();
+			console.log("Before Load");
+			if (!socket || socket == undefined)
+				socket = new Socket(localStorage.getItem('access'));
+			socket.lobbyLoad(localStorage.getItem('access'));
 			if (!element) {
 				renderElement("overview");
 			} else {
@@ -96,7 +93,6 @@ async function renderPage(page, element) {
 			}
 
 		} else if (page === "pong") {
-			window.removeEventListener("popstate", handlePopState);
 			startGame3d(data, socket);
 		} else if (page === "42") {
 			handle42Callback();
@@ -116,7 +112,6 @@ async function renderPage(page, element) {
 }
 
 async function renderAuthPage(page, responseStruct) {
-	// console.log(`Attempting to render page: ${page}`);
 	const loadingOverlay = new LoadingOverlay();
 
 	try {
@@ -275,41 +270,6 @@ async function refreshTokenDiff(tokens) {
 		return false;
 	}
 }
-
-
-const handlePopState = async (e) => {
-	if (e.state?.page) {
-		let path = window.location.pathname.slice(1) || "home";
-		console.log(path);
-
-		if (path === "home" || path === "pong" || path === "pongai" || path === "ponglocal" || elements.elements[path]) {
-			const authenticated = await isAuthenticated();
-			if (!authenticated) {
-				console.log("User not authenticated, redirecting to login page.");
-				history.pushState({ page: "login" }, "", "/login");
-				path = "login";
-			}
-		}
-		else if (path === "login" || path === "register" || path === "42") {
-			const authenticated = await isAuthenticated();
-			if (authenticated) {
-				console.log("User authenticated, redirecting to home page.");
-				history.pushState({ page: "home" }, "", "/home");
-				path = "home";
-			}
-		}
-
-		if (!router.pages[path] && !elements.elements[path] && !routerAuth.pages[path]) {
-			renderPage("404");
-		}
-		else if (router.pages[path]) {
-			renderPage(path);
-		}
-		else if (elements.elements[path]) {
-			renderPage("home", path);
-		}
-	}
-};
 
 // Load initial page
 window.addEventListener("load", async () => {


### PR DESCRIPTION
This pull request includes multiple changes to the `Frontend/assets/js/main.js` file, primarily focusing on removing the `handlePopState` function and its associated event listeners. These changes simplify the code and remove unused or redundant functionality.

Code simplification:

* Removed the `handlePopState` function and its associated event listener from the `renderPage` function.
* Removed the `popstate` event listener from the `renderPage` function for the "pong" page.
* Removed the `popstate` event listener setup from the `renderPage` function.

Cleanup:

* Removed a commented-out `console.log` statement from the `renderAuthPage` function.… simplifying home page logic