### PR TITLE
Add favicon link to index.html

### DIFF
--- a/Frontend/index.html
+++ b/Frontend/index.html
@@ -6,6 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta name="description" content="" />
 	<title>Transcendence</title>
+	<link rel="icon" type="image/png" sizes="16x16" href="/assets/img/42Logo.png">
 	<link rel="canonical" href="https://getbootstrap.com/docs/5.3/examples/dashboard/" />
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@docsearch/css@3" />
 	<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.min.css" rel="stylesheet" />


### PR DESCRIPTION
This pull request includes a small change to the `Frontend/index.html` file. The change adds a link to set a favicon for the webpage.

* [`Frontend/index.html`](diffhunk://#diff-95aa506b5fe2ea71174bcc8d0c0e1fd7bb61fe0171d5de23035d8548a5a9af63R9): Added a link to set the favicon with the `42Logo.png` image.