### PR TITLE
Update Nginx configuration to use specific backend and frontend servi…

### DIFF
--- a/Server/nginx.conf
+++ b/Server/nginx.conf
@@ -19,7 +19,7 @@ server {
     ssl_certificate_key /etc/nginx/ssl/nginx.key;
 
     location / {
-        proxy_pass http://frontend:9000;
+        proxy_pass http://transcendance_frontend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -31,7 +31,7 @@ server {
     }
 
     location /api/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://transcendance_backend;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -43,7 +43,7 @@ server {
     }
  
     location /ws/ {
-        proxy_pass http://backend:8000;
+        proxy_pass http://transcendance_backend;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
This pull request includes changes to the `Server/nginx.conf` file to update the proxy pass settings for different locations. The changes ensure that the proxy pass URLs are updated to use the correct service names.

Proxy pass updates:

* Updated the `proxy_pass` URL for the root location to `http://transcendance_frontend` instead of `http://frontend:9000`.
* Updated the `proxy_pass` URL for the `/api/` location to `http://transcendance_backend` instead of `http://backend:8000`.
* Updated the `proxy_pass` URL for the `/ws/` location to `http://transcendance_backend` instead of `http://backend:8000`.…ce names